### PR TITLE
Add FieldBase, to allow users to create custom fields.

### DIFF
--- a/flaskext/wtf/__init__.py
+++ b/flaskext/wtf/__init__.py
@@ -26,6 +26,7 @@ from wtforms.widgets import CheckboxInput, FileInput, HiddenInput, \
     ListWidget, Option, PasswordInput, RadioInput, Select, SubmitInput, \
     TableWidget, TextArea, TextInput
 
+from wtforms.fields import Field as FieldBase
 from wtforms.fields import FileField as _FileField
 
 try:


### PR DESCRIPTION
Custom fields in WTForms inherit from wtforms.fields.Field.  As it stands, to create a custom field in a Flask app, the user must import the Field base class from wtforms.

As all of the standard fields are included in this module to allow the user to import them directly (without requiring importing wtforms separately), it seems consistent to do the same with the base class as well.
