### PR TITLE
Add missing parens for Form.is_submitted()

### DIFF
--- a/flaskext/wtf/form.py
+++ b/flaskext/wtf/form.py
@@ -41,7 +41,7 @@ class Form(SessionSecureForm):
         self.csrf_enabled = csrf_enabled
 
         if formdata is _Auto:
-            if self.is_submitted:
+            if self.is_submitted():
                 formdata = request.form
                 if request.files:
                     formdata = formdata.copy()


### PR DESCRIPTION
I don't think this actually fixes any bugs; even though the test is always evaluating to `True` right now, it's setting `formdata` to `request.form`, which will be empty if `Form.is_submitted() == False`. This is just for the sake of correctness; `formdata` really should be None if it's not a PUT/POST request.
