### PR TITLE
Boilerplate support for request.json data

### DIFF
--- a/flaskext/wtf/form.py
+++ b/flaskext/wtf/form.py
@@ -1,3 +1,5 @@
+import werkzeug.datastructures
+
 from jinja2 import Markup
 from flask import request, session, current_app
 from wtforms.fields import HiddenField
@@ -46,6 +48,8 @@ class Form(SessionSecureForm):
                 if request.files:
                     formdata = formdata.copy()
                     formdata.update(request.files)
+                elif request.json:
+                    formdata = werkzeug.datastructures.MultiDict(request.json);
             else:
                 formdata = None
         if self.csrf_enabled:


### PR DESCRIPTION
Besides request.form and request.files, added support for request.json (useful for RESTful API).
