### PR TITLE
Fix exmaple in docs with wtforms.TextField

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,7 +104,7 @@ Creating forms
     from wtforms import TextField, validators
 
     class MyForm(Form):
-        name = TextField(name, validators=[validators.DataRequired()])
+        name = TextField("name", validators=[validators.DataRequired()])
 
 In addition, a CSRF token hidden field is created. You can print this in your
 template as any other field::


### PR DESCRIPTION
When starting using flask-wtf I've stumbled over the following problem in the docs:
The first argument to Textfield was a variable name, that's not definied. It should be a string.

It's a really minor fix, but will probably save new users a few minutes.
