### PR TITLE
Really always validate when app.testing == True

### DIFF
--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -38,7 +38,7 @@ class Recaptcha(object):
         response = request.form.get('recaptcha_response_field', '')
         remote_ip = request.remote_addr
 
-        if not challenge or not response:
+        if not current_app.testing and (not challenge or not response):
             raise ValidationError(field.gettext(self.message))
 
         if not self._validate_recaptcha(challenge, response, remote_ip):


### PR DESCRIPTION
The docs say that this field will always validate with app.testing == True. I think this is a good thing. However, the current behavior doesn't reflect this. If there is no input, it doesn't validate. It should validate, though. Testing systems might not have any kind of recaptcha key set up in which case the widget will not display and you can't put any input into there.

Hence, we should simply always validate on app.testing == True.
