### PR TITLE
Correct documentation for setting csrftoken in $.ajaxSetup

### DIFF
--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -111,7 +111,7 @@ Whenever you send a AJAX POST request, add the ``X-CSRFToken`` for it:
     $.ajaxSetup({
         beforeSend: function(xhr, settings) {
             if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
-                xhrf.xhr.setRequestHeader("X-CSRFToken", csrftoken)
+                xhr.setRequestHeader("X-CSRFToken", csrftoken)
             }
         }
     })


### PR DESCRIPTION
Documentation for setting csrftoken contains references undeclared "xhrf".
