### PR TITLE
Minor improvements to the Quickstart document

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -60,8 +60,8 @@ Validating the request in your view handlers::
             return redirect('/success')
         return render_template('submit.html', form=form)
 
-Note that, you don't have to pass ``request.form`` to Flask-WTF, it will
-load automatically. And the convience ``validate_on_submit`` will check
+Note that you don't have to pass ``request.form`` to Flask-WTF; it will
+load automatically. And the convenience ``validate_on_submit`` will check
 if it is a POST request and if it is valid.
 
 Heading over to :doc:`form` to learn more skills.


### PR DESCRIPTION
Most important is the change in the illustrative example for the route receiving the form submission from ('GET', 'POST') to ['GET', 'POST']— at least in Flask 0.10.1 the square bracket list notation is required.
