### PR TITLE
find csrf_token field if form has prefix

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -157,7 +157,11 @@ class CsrfProtect(object):
 
             csrf_token = None
             if request.method in ('POST', 'PUT', 'PATCH'):
-                csrf_token = request.form.get('csrf_token')
+                # find the ``csrf_token`` field in the subitted form
+                # if the form had a prefix, the name will be ``{prefix}-csrf_token``
+                for key in request.form:
+                    if key.endswith('csrf_token'):
+                        csrf_token = request.form[key]
             if not csrf_token:
                 # You can get csrf token from header
                 # The header name is the same as Django

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -80,6 +80,16 @@ class TestCSRF(TestCase):
         })
         assert b'DANNY' in response.data
 
+    def test_prefixed_csrf(self):
+        response = self.client.get('/')
+        csrf_token = get_csrf_token(response.data)
+
+        response = self.client.post('/', data={
+            'prefix-name': 'David',
+            'prefix-csrf_token': csrf_token,
+        })
+        assert response.status_code == 200
+
     def test_invalid_secure_csrf(self):
         response = self.client.get("/", base_url='https://localhost/')
         csrf_token = get_csrf_token(response.data)


### PR DESCRIPTION
If a form was initialized as `Form(prefix='hello')`, then the `csrf_token` field will have the name `'hello-csrf_token'`, and CsrfProtect will fail to recognize it.

This change checks all keys to find one that ends with `'csrf_token'`.
