### PR TITLE
Install csrf_token() for all template types.

### DIFF
--- a/flask_wtf/__init__.py
+++ b/flask_wtf/__init__.py
@@ -16,4 +16,4 @@ from .form import Form
 from .csrf import CsrfProtect
 from .recaptcha import *
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -130,9 +130,13 @@ class CsrfProtect(object):
             self.init_app(app)
 
     def init_app(self, app):
-        app.jinja_env.globals['csrf_token'] = generate_csrf
         app.config.setdefault('WTF_CSRF_SSL_STRICT', True)
         app.config.setdefault('WTF_CSRF_ENABLED', True)
+
+        # expose csrf_token as a helper in all templates
+        @app.context_processor
+        def csrf_token():
+            return dict(csrf_token=generate_csrf)
         
         @app.before_request
         def _csrf_protect():

--- a/tests/templates/csrf.html
+++ b/tests/templates/csrf.html
@@ -1,0 +1,8 @@
+
+<!DOCTYPE html>
+
+<html>
+    <body>
+        token: {{ csrf_token() }}
+    </body>
+</html>

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -184,3 +184,11 @@ class TestCSRF(TestCase):
             assert not validate_csrf('ff##dd')
             csrf_token = generate_csrf()
             assert validate_csrf(csrf_token)
+
+    def test_csrf_token_helper(self):
+        @self.app.route("/token")
+        def withtoken():
+            return render_template("csrf.html")
+
+        response = self.client.get('/token')
+        assert re.compile('token: [a-zA-Z0-9#.]{3,}').search(response.data)


### PR DESCRIPTION
This installs csrf_token() in the render context so that
it works by default for all template types, not just Jinja2.

Also adds a test for the helper function and bumps the version
number.
