### PR TITLE
FileAllowed: bug fix for uppercase filename with uploadset

### DIFF
--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -68,7 +68,8 @@ class FileAllowed(object):
                 return
             raise ValidationError(self.message)
 
-        if not self.upload_set.file_allowed(field.data, field.data.filename):
+        if not self.upload_set.file_allowed(field.data,
+                field.data.filename.lower()):
             raise ValidationError(self.message)
 
 file_allowed = FileAllowed


### PR DESCRIPTION
When filename has uppercase extension filename with uploadset, FileAllowed will raise error. For example when an image has extension `JPG` rather than `jpg`, the validator will fail. We should use lower filename for uploadset validation.
