### PR TITLE
Add csrf_token() to Jinja2 globals

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -130,6 +130,7 @@ class CsrfProtect(object):
             self.init_app(app)
 
     def init_app(self, app):
+        app.jinja_env.globals['csrf_token'] = generate_csrf
         app.config.setdefault('WTF_CSRF_SSL_STRICT', True)
         app.config.setdefault('WTF_CSRF_ENABLED', True)
         app.config.setdefault('WTF_CSRF_METHODS', ['POST', 'PUT', 'PATCH'])

--- a/tests/templates/csrf_macro.html
+++ b/tests/templates/csrf_macro.html
@@ -1,0 +1,3 @@
+{% macro render_csrf_token() %}
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+{% endmacro %}

--- a/tests/templates/import_csrf.html
+++ b/tests/templates/import_csrf.html
@@ -1,0 +1,2 @@
+{% import "csrf_macro.html" as h %}
+{{ h.render_csrf_token() }}

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -192,3 +192,11 @@ class TestCSRF(TestCase):
 
         response = self.client.get('/token')
         assert b'#' in response.data
+
+    def test_csrf_token_macro(self):
+        @self.app.route("/token")
+        def withtoken():
+            return render_template("import_csrf.html")
+
+        response = self.client.get('/token')
+        assert b'#' in response.data


### PR DESCRIPTION
Installing csrf_token() in the render context only causes errors in
imported Jinja2 templates. It can be avoided by explicitly importing
templates with context, but it is a cognitive burden to remember which
templates should be imported with context and which don't have to be.
