### PR TITLE
Fix csrf validation without time limit (time_limit=False)

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -74,15 +74,16 @@ def validate_csrf(data, secret_key=None, time_limit=None):
         return False
 
     expires, hmac_csrf = data.split('##', 1)
-    try:
-        expires = float(expires)
-    except:
-        return False
 
     if time_limit is None:
         time_limit = current_app.config.get('WTF_CSRF_TIME_LIMIT', 3600)
 
     if time_limit:
+        try:
+            expires = float(expires)
+        except:
+            return False
+
         now = time.time()
         if now > expires:
             return False

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -185,6 +185,11 @@ class TestCSRF(TestCase):
             csrf_token = generate_csrf()
             assert validate_csrf(csrf_token)
 
+    def test_validate_not_expiring_csrf(self):
+        with self.app.test_request_context():
+            csrf_token = generate_csrf(time_limit=False)
+            assert validate_csrf(csrf_token, time_limit=False)
+
     def test_csrf_token_helper(self):
         @self.app.route("/token")
         def withtoken():


### PR DESCRIPTION
With `time_limit=False`, `generate_csrf` will generate a token with an empty `expires` value. The `validate_csrf` function will always fail because it tries to parse an empty string as float. We should parse this value only if we care about the `time_limit`.
