### PR TITLE
File allowed stop validation

### DIFF
--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -67,9 +67,12 @@ class FileAllowed(object):
             ext = filename.rsplit('.', 1)[-1]
             if ext in self.upload_set:
                 return
-            raise StopValidation(self.message)
+            message = '{} is not in the allowed extentions: {}'.format(
+                ext, self.upload_set)
+            raise StopValidation(self.message or message)
 
         if not self.upload_set.file_allowed(field.data, filename):
-            raise StopValidation(self.message)
+            raise StopValidation(self.message or
+                                 'File does not have an approved extension')
 
 file_allowed = FileAllowed


### PR DESCRIPTION
Unfortunately it did break something! `StopValidation` doesn't behave correctly if there is no message. I'm going to report this as a bug to WTForms, but for now I set default messages.
