### PR TITLE
Update csrf.rst

### DIFF
--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -110,7 +110,7 @@ Whenever you send a AJAX POST request, add the ``X-CSRFToken`` for it:
 
     $.ajaxSetup({
         beforeSend: function(xhr, settings) {
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+            if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
                 xhr.setRequestHeader("X-CSRFToken", csrftoken)
             }
         }


### PR DESCRIPTION
Make sure to never send the CSRF token to other domains. crossDomain is in jQuery 1.5.1+
