### PR TITLE
Don't use floating point for expiration

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -49,7 +49,7 @@ def generate_csrf(secret_key=None, time_limit=None):
         session['csrf_token'] = hashlib.sha1(os.urandom(64)).hexdigest()
 
     if time_limit:
-        expires = time.time() + time_limit
+        expires = int(time.time() + time_limit)
         csrf_build = '%s%s' % (session['csrf_token'], expires)
     else:
         expires = ''
@@ -82,11 +82,11 @@ def validate_csrf(data, secret_key=None, time_limit=None):
 
     if time_limit:
         try:
-            expires = float(expires)
+            expires = int(expires)
         except:
             return False
 
-        now = time.time()
+        now = int(time.time())
         if now > expires:
             return False
 


### PR DESCRIPTION
On one of my machines, the return value of time.time() seem to have
different precision from other floats. This means that the value
generated by time.time() cannot be converted back to a float when
validating the CSRF signature. See example below. I also don't see why
we would need sub second precision here, so I just changed the
expiration value to be an int.

> > > t = time.time()
> > > t
> > > 1412343858.6668283
> > > float(t)
> > > 1412343858.6668283
> > > s = '%s' % t
> > > '1412343858.6668283'
> > > float(s)
> > > 1412343858.6668286
> > > t2 = 1412343858.6668283
> > > t2
> > > 1412343858.6668286

There are alternative approaches to this, such as keeping the float and doing the hmac verification earlier, on the string. The cast to float is just for comparison with time.time() anyway
