### PR TITLE
Add configuration: WTF_CSRF_HEADERS

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,6 +14,8 @@ WTF_CSRF_ENABLED     Disable/enable CSRF protection for forms.
                      Default is True.
 WTF_I18N_ENABLED     Disable/enable I18N support. This should work
                      together with Flask-Babel. Default is True.
+WTF_CSRF_HEADERS     CSRF token HTTP headers checked. Default is
+                     **['X-CSRFToken', 'X-CSRF-Token']**
 WTF_CSRF_SECRET_KEY  A random string for generating CSRF token.
                      Default is the same as SECRET_KEY.
 WTF_CSRF_TIME_LIMIT  CSRF token expiring time. Default is **3600**

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -170,6 +170,40 @@ class TestCSRF(TestCase):
         )
         assert response.status_code == 200
 
+    def test_empty_csrf_headers(self):
+        response = self.client.get("/", base_url='https://localhost/')
+        csrf_token = get_csrf_token(response.data)
+        self.app.config['WTF_CSRF_HEADERS'] = list()
+        response = self.client.post(
+            "/",
+            data={"name": "danny"},
+            headers={
+                'X-CSRFToken': csrf_token,
+            },
+            environ_base={
+                'HTTP_REFERER': 'https://localhost/',
+            },
+            base_url='https://localhost/',
+        )
+        assert response.status_code == 400
+
+    def test_custom_csrf_headers(self):
+        response = self.client.get("/", base_url='https://localhost/')
+        csrf_token = get_csrf_token(response.data)
+        self.app.config['WTF_CSRF_HEADERS'] = ['X-XSRF-TOKEN']
+        response = self.client.post(
+            "/",
+            data={"name": "danny"},
+            headers={
+                'X-XSRF-TOKEN': csrf_token,
+            },
+            environ_base={
+                'HTTP_REFERER': 'https://localhost/',
+            },
+            base_url='https://localhost/',
+        )
+        assert response.status_code == 200
+
     def test_not_endpoint(self):
         response = self.client.post('/not-endpoint')
         assert response.status_code == 404


### PR DESCRIPTION
It is convenient to be able to configure the headers that are checked
for CSRF token presence.  Especially when working with existing
frameworks, such as AngularJS, which have built-in support for handling
CSRF/XSRF cookies and tokens.  This commit adds such a configuration
option, preserving the existing two headers (`X-CSRFToken` and
`X-CSRF-Token`) as the default.  Test cases have been added for the
empty and modified configuration option conditions.

See also:
- https://docs.angularjs.org/api/ng/service/$http
