### PR TITLE
Fix example uploadr - wrong FieldList import

### DIFF
--- a/examples/uploadr/app.py
+++ b/examples/uploadr/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template
 from flask_wtf import Form
-from flask_wtf.file import FileField, FieldList
-
+from flask_wtf.file import FileField
+from wtforms import FieldList
 
 class FileUploadForm(Form):
     uploads = FieldList(FileField())


### PR DESCRIPTION
The uploadr example failed with the following error message:

```bash
~/workspace/examples/uploadr$ python app.py   
Traceback (most recent call last):
      File "app.py", line 2, in <module>        
         from flask_wtf import Form, FieldList
ImportError: cannot import name FieldList
```

Changing the import for `FieldList` removed the error.