### PR TITLE
adding validation to HTML form

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -2,8 +2,10 @@
 
 import werkzeug.datastructures
 
+from functools import wraps
 from jinja2 import Markup, escape
-from flask import request, session, current_app, redirect, render_template
+from flask import (request, session, current_app, redirect, render_template,
+                    url_for)
 from wtforms.fields import HiddenField
 from wtforms.widgets import HiddenInput
 from wtforms.validators import ValidationError


### PR DESCRIPTION
I see that many people end up very pollute his view as do things like check for the type of request. Another thing that greatly pollutes the view is when the developer chooses to use an HTML form instead of using an instantiated class wtforms. For this reason he ends up doing the validation of these fields also in view, which ends up polluting it further. To work around this, I implemented a decorator that allows the developer to not worry about the type of request or with the validation of this field in the HTML form, allowing the same make in view only what he should do and nothing more