### PR TITLE
Re-Captcha validation fix

### DIFF
--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -70,8 +70,9 @@ class Recaptcha(object):
         if json_resp["success"]:
             return True
 
-        for error in json_resp.get("error-codes", []):
-            if error in RECAPTCHA_ERROR_CODES:
-                raise ValidationError(RECAPTCHA_ERROR_CODES[error])
+        if "error-codes" in json_resp:
+            for error in json_resp.get("error-codes", []):
+                if error in RECAPTCHA_ERROR_CODES:
+                    raise ValidationError(RECAPTCHA_ERROR_CODES[error])
 
         return False


### PR DESCRIPTION
As per the API's documentation error-codes are optional. I added a check before using it.
```
The response is a JSON object:

{
  "success": true|false,
  "error-codes": [...]   // optional
}
```

Note that this is my first pull request. Let me know if i did something wrong :)