### PR TITLE
secure_filename should be imported from werkzeug.utils

### DIFF
--- a/docs/form.rst
+++ b/docs/form.rst
@@ -39,7 +39,7 @@ instance of Werkzeug FileStorage.
 
 For example::
 
-    from werkzeug import secure_filename
+    from werkzeug.utils import secure_filename
     from flask_wtf.file import FileField
 
     class PhotoForm(Form):


### PR DESCRIPTION
Atleast from v0.9, secure_filename is under [`werkzeug.utils`](http://werkzeug.pocoo.org/docs/0.10/utils/#werkzeug.utils.secure_filename). In the [documentation](https://flask-wtf.readthedocs.org/en/latest/form.html#module-flask_wtf.file) it is still imported from `werkzeug`.