### PR TITLE
Append `X-XSRF-Token` to `WTF_CSRF_HEADERS`.

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -143,7 +143,7 @@ class CsrfProtect(object):
         self._app = app
         app.jinja_env.globals['csrf_token'] = generate_csrf
         app.config.setdefault(
-            'WTF_CSRF_HEADERS', ['X-CSRFToken', 'X-CSRF-Token']
+            'WTF_CSRF_HEADERS', ['X-CSRFToken', 'X-CSRF-Token', 'X-XSRF-Token', ]
         )
         app.config.setdefault('WTF_CSRF_SSL_STRICT', True)
         app.config.setdefault('WTF_CSRF_ENABLED', True)


### PR DESCRIPTION
In angular, when performing XHR requests, the $http service
reads a token from a cookie (by default, `XSRF-TOKEN`) and sets
it as an HTTP header `X-XSRF-TOKEN`.

Source: https://docs.angularjs.org/api/ng/service/$http