### PR TITLE
Repaired 404 exemption inconsistency

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -165,14 +165,14 @@ class CsrfProtect(object):
             if request.method not in app.config['WTF_CSRF_METHODS']:
                 return
 
+            if not request.endpoint:
+                return
+
+            view = app.view_functions.get(request.endpoint)
+            if not view:
+                return
+
             if self._exempt_views or self._exempt_blueprints:
-                if not request.endpoint:
-                    return
-
-                view = app.view_functions.get(request.endpoint)
-                if not view:
-                    return
-
                 dest = '%s.%s' % (view.__module__, view.__name__)
                 if dest in self._exempt_views:
                     return


### PR DESCRIPTION
We have noticed an inconsistent behavior for when a 404 is being exempted/not exempted from a CSRF check.

Initially in our repo, we had no `@csrf.exempt` calls and so a test like the following would receive a CSRF error (not a 404):

```python
@app.route('/foo', methods=('GET', 'POST'))
def my_handler():
  return 'ok'

# CSRF error encountered on this request
self.app.post('/not-an-endpoint')
```

However, after we add an `@csrf.exempt` to an existing endpoint, we noticed that we would instead yield a 404 at the endpoint in our tests:

```python
@csrf.exempt
@app.route('/foo', methods=('GET', 'POST'))
def my_handler():
  return 'ok'

# 404 encountered on this request, not a CSRF error
self.app.post('/not-an-endpoint')
```

This inconsistent behavior is undesirable as some people might be writing integration tests to verify CSRF works.

To remedy that, we have decided to exempt all 404 requests to CSRF checks. In this PR:

- Relocated 404 exemption for CSRF checks outside of `self._exempt_views or self._exempt_blueprints` conditional