### PR TITLE
Remove port comparison from same_origin()

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -268,7 +268,4 @@ def same_origin(current_uri, compare_uri):
 
     if parsed_uri.hostname != parsed_compare.hostname:
         return False
-
-    if parsed_uri.port != parsed_compare.port:
-        return False
     return True


### PR DESCRIPTION
`same_origin` returns False if the referrer port and current host are not equal, resulting in a Bad Request - Referrer checking failed - origin does not match.

This is problematic when Nginx is proxy passing requests to a Gunicorn application running Flask. Nginx is running on one port, and Gunicorn on another.