### PR TITLE
Remove port comparison from same_origin()

### DIFF
--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -146,19 +146,7 @@ class TestCSRF(TestCase):
         assert response.status_code == 400
         assert b'not match' in response.data
 
-        response = self.client.post(
-            "/",
-            data={"name": "danny"},
-            headers={
-                'X-CSRFToken': csrf_token,
-            },
-            environ_base={
-                'HTTP_REFERER': 'https://localhost:3000/',
-            },
-            base_url='https://localhost/',
-        )
-        assert response.status_code == 400
-        assert b'not match' in response.data
+        
 
     def test_valid_secure_csrf(self):
         response = self.client.get("/", base_url='https://localhost/')
@@ -171,6 +159,19 @@ class TestCSRF(TestCase):
             },
             environ_base={
                 'HTTP_REFERER': 'https://localhost/',
+            },
+            base_url='https://localhost/',
+        )
+        assert response.status_code == 200
+        
+        response = self.client.post(
+            "/",
+            data={"name": "danny"},
+            headers={
+                'X-CSRFToken': csrf_token,
+            },
+            environ_base={
+                'HTTP_REFERER': 'https://localhost:3000/',
             },
             base_url='https://localhost/',
         )


### PR DESCRIPTION
same_origin returns False if the referrer port and current host are not equal, resulting in a Bad Request - Referrer checking failed - origin does not match.

This is problematic when Nginx is proxy passing requests to a Gunicorn application running Flask. Nginx is running on one port, and Gunicorn on another.

I have opened a Issue [here](https://github.com/lepture/flask-wtf/issues/223).
