### PR TITLE
Nginx and Gunicorn with CsrfProtect Referrer checking failed - origin does not match due to port comparison in csrf.same_origin function

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -269,6 +269,4 @@ def same_origin(current_uri, compare_uri):
     if parsed_uri.hostname != parsed_compare.hostname:
         return False
 
-    if parsed_uri.port != parsed_compare.port:
-        return False
     return True

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -146,20 +146,6 @@ class TestCSRF(TestCase):
         assert response.status_code == 400
         assert b'not match' in response.data
 
-        response = self.client.post(
-            "/",
-            data={"name": "danny"},
-            headers={
-                'X-CSRFToken': csrf_token,
-            },
-            environ_base={
-                'HTTP_REFERER': 'https://localhost:3000/',
-            },
-            base_url='https://localhost/',
-        )
-        assert response.status_code == 400
-        assert b'not match' in response.data
-
     def test_valid_secure_csrf(self):
         response = self.client.get("/", base_url='https://localhost/')
         csrf_token = get_csrf_token(response.data)
@@ -171,6 +157,19 @@ class TestCSRF(TestCase):
             },
             environ_base={
                 'HTTP_REFERER': 'https://localhost/',
+            },
+            base_url='https://localhost/',
+        )
+        assert response.status_code == 200
+        
+        response = self.client.post(
+            "/",
+            data={"name": "danny"},
+            headers={
+                'X-CSRFToken': csrf_token,
+            },
+            environ_base={
+                'HTTP_REFERER': 'https://localhost:3000/',
             },
             base_url='https://localhost/',
         )


### PR DESCRIPTION
Please refer to [Issue 223](https://github.com/lepture/flask-wtf/issues/223)

This function fails when Nginx is passing a request to Gunicorn because they are on different ports. Removing the port comparison solved the issue.

Coverage has decreased because of the two lines that I removed.