### PR TITLE
fix example code

### DIFF
--- a/docs/form.rst
+++ b/docs/form.rst
@@ -39,7 +39,7 @@ instance of Werkzeug FileStorage.
 
 For example::
 
-    from werkzeug import secure_filename
+    from werkzeug.utils import secure_filename
     from flask_wtf.file import FileField
 
     class PhotoForm(Form):


### PR DESCRIPTION
In the current version of werkzeug, the secure_filename method must be imported from werkzeug.utils