### PR TITLE
Fix csrf.error_handler example in docs

### DIFF
--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -61,9 +61,13 @@ But if the template has no forms, you still need a csrf token:
 Whenever a CSRF validation fails, it will return a 400 response. You can
 customize the error response::
 
+    from flask import abort
+    from werkzeug.wrappers import Response
+    
     @csrf.error_handler
     def csrf_error(reason):
-        return render_template('csrf_error.html', reason=reason), 400
+        abort(Response(render_template('csrf_error.html', reason=reason), 
+              status=400, content_type='text/html'))
 
 We strongly suggest that you protect all your views with CSRF. But if
 needed, you can exclude some views using a decorator::


### PR DESCRIPTION
The example code in the docs for @csrf.error_handler does not work correctly (as noted in #200). Rather than showing a custom error page for CSRF violations, it silences all CSRF errors across the app. 

This change alters the example to correctly show a custom error page, using the code written by @wobsta in #200. I tested the new example code in versions 0.12 and 0.11.

From testing the existing example on 0.11 and 0.12, it looks like what actually happened here is a regression, specifically during the refactor in e85808b9e7432f4e5b782032e32ad8cc3939e7d1. A fix was proposed but rejected in #209. In lieu of making that change or otherwise patching this, it'd be good to update the docs with a working example. Someone using the existing example code with version 0.12 would actually not have CSRF protection at all.