### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,4 +22,4 @@ and Recaptcha integration.
 
 For more information please refer to the online docs:
 
-https://flask-wtf.readthedocs.org
+https://flask-wtf.readthedocs.io

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,7 +16,7 @@ or, with `easy_install <http://pypi.python.org/pypi/setuptools>`_::
 
     $ easy_install Flask-WTF
 
-But, you really `shouldn't do that <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/>`_.
+But, you really `shouldn't do that <https://python-packaging-user-guide.readthedocs.io/en/latest/pip_easy_install/>`_.
 
 
 Get the Code

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ and Recaptcha integration.
 Links
 -----
 
-* `documentation <https://flask-wtf.readthedocs.org>`_
+* `documentation <https://flask-wtf.readthedocs.io>`_
 * `development version
   <http://github.com/lepture/flask-wtf>`_
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.