### PR TITLE
Use request.get_json() instead of request.json

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -75,8 +75,8 @@ class Form(SecureForm):
                 if request.files:
                     formdata = formdata.copy()
                     formdata.update(request.files)
-                elif request.json:
-                    formdata = werkzeug.datastructures.MultiDict(request.json)
+                elif request.get_json():
+                    formdata = werkzeug.datastructures.MultiDict(request.get_json())
             else:
                 formdata = None
 


### PR DESCRIPTION
As of Flask-0.11, request.json has been deprecated.
http://flask.pocoo.org/docs/0.11/changelog/

Tests pass locally:

~~~
(env)Achal’s Macbook:flask-wtf achal$ make test
.........................
----------------------------------------------------------------------
Ran 50 tests in 0.532s

OK
~~~