### PR TITLE
form: allow form.data to be accessed multiple times

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -172,7 +172,7 @@ class Form(SecureForm):
         d = super(Form, self).data
         # https://github.com/lepture/flask-wtf/issues/208
         if self.csrf_enabled:
-            d.pop('csrf_token')
+            d.pop('csrf_token', None)
         return d
 
     def _get_translations(self):


### PR DESCRIPTION
The first access of form.data removes the 'csrf_token' key, and
breaks on subsequent accesses.  Guard the pop() call so that a
missing value is a no-op.

Closes #208
Signed-off-by: David Aguilar <davvid@gmail.com>