### PR TITLE
Rename Form to FlaskForm

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,8 +8,10 @@ Forms and Fields
 
 .. module:: flask_wtf
 
-.. autoclass:: Form
-   :members:
+.. autoclass:: FlaskForm
+    :members:
+
+.. autoclass:: Form(...)
 
 .. autoclass:: RecaptchaField
 

--- a/examples/babel/app.py
+++ b/examples/babel/app.py
@@ -1,12 +1,12 @@
 from flask import Flask, render_template, request
 from wtforms import TextField
 from wtforms.validators import DataRequired
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_babel import Babel
 from flask_babel import lazy_gettext as _
 
 
-class BabelForm(Form):
+class BabelForm(FlaskForm):
     name = TextField(_('Name'), validators=[DataRequired()])
 
 

--- a/examples/flaskr/flaskr.py
+++ b/examples/flaskr/flaskr.py
@@ -14,7 +14,7 @@
 from __future__ import with_statement
 from flask import (Flask, session, redirect, url_for, abort,
                    render_template, flash)
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms import TextField, TextAreaField, PasswordField, SubmitField
 from wtforms.validators import DataRequired, ValidationError
 from flask_sqlalchemy import SQLAlchemy
@@ -46,14 +46,14 @@ class Entry(db.Model):
 db.create_all()
 
 
-class EntryForm(Form):
+class EntryForm(FlaskForm):
 
     title = TextField("Title", validators=[DataRequired()])
     text = TextAreaField("Text")
     submit = SubmitField("Share")
 
 
-class LoginForm(Form):
+class LoginForm(FlaskForm):
 
     username = TextField("Username")
     password = PasswordField("Password")

--- a/examples/recaptcha/app.py
+++ b/examples/recaptcha/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, flash, session, redirect, url_for
 from wtforms import TextAreaField
 from wtforms.validators import DataRequired
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf.recaptcha import RecaptchaField
 
 
@@ -17,7 +17,7 @@ app = Flask(__name__)
 app.config.from_object(__name__)
 
 
-class CommentForm(Form):
+class CommentForm(FlaskForm):
 
     comment = TextAreaField("Comment", validators=[DataRequired()])
     recaptcha = RecaptchaField()

--- a/examples/uploadr/app.py
+++ b/examples/uploadr/app.py
@@ -1,9 +1,9 @@
 from flask import Flask, render_template
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
 from wtforms import FieldList
 
-class FileUploadForm(Form):
+class FileUploadForm(FlaskForm):
     uploads = FieldList(FileField())
 
 DEBUG = True

--- a/flask_wtf/__init__.py
+++ b/flask_wtf/__init__.py
@@ -12,7 +12,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 
-from .form import Form
+from .form import FlaskForm, Form
 from .csrf import CsrfProtect
 from .recaptcha import *
 

--- a/flask_wtf/_compat.py
+++ b/flask_wtf/_compat.py
@@ -1,4 +1,6 @@
 import sys
+import warnings
+
 if sys.version_info[0] == 3:
     text_type = str
     string_types = (str,)
@@ -19,3 +21,11 @@ def to_unicode(input_bytes, encoding='utf-8'):
     if not isinstance(input_bytes, string_types):
         input_bytes = input_bytes.decode(encoding)
     return input_bytes
+
+
+class FlaskWTFDeprecationWarning(DeprecationWarning):
+    pass
+
+
+warnings.simplefilter('always', FlaskWTFDeprecationWarning)
+warnings.filterwarnings('ignore', category=FlaskWTFDeprecationWarning, module='wtforms|flask_wtf')

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 from flask import Flask, render_template, jsonify
 from wtforms import StringField, HiddenField, SubmitField
 from wtforms.validators import DataRequired
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf._compat import text_type
 
 
@@ -13,13 +13,13 @@ def to_unicode(text):
     return text
 
 
-class MyForm(Form):
+class MyForm(FlaskForm):
     SECRET_KEY = "a poorly kept secret."
     name = StringField("Name", validators=[DataRequired()])
     submit = SubmitField("Submit")
 
 
-class HiddenFieldsForm(Form):
+class HiddenFieldsForm(FlaskForm):
     SECRET_KEY = "a poorly kept secret."
     name = HiddenField()
     url = HiddenField()
@@ -32,7 +32,7 @@ class HiddenFieldsForm(Form):
         self.method.name = '_method'
 
 
-class SimpleForm(Form):
+class SimpleForm(FlaskForm):
     SECRET_KEY = "a poorly kept secret."
     pass
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,0 +1,15 @@
+import warnings
+from unittest import TestCase
+from flask_wtf import Form
+from flask_wtf._compat import FlaskWTFDeprecationWarning
+
+
+class TestForm(TestCase):
+    def test_deprecated_form(self):
+        def define_deprecated_form():
+            class F(Form):
+                pass
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', FlaskWTFDeprecationWarning)
+            self.assertRaises(FlaskWTFDeprecationWarning, define_deprecated_form)

--- a/tests/test_recaptcha.py
+++ b/tests/test_recaptcha.py
@@ -3,7 +3,7 @@ from __future__ import with_statement
 from .base import TestCase
 from flask import json
 from flask import Flask, render_template
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf.recaptcha import RecaptchaField
 
 
@@ -11,7 +11,7 @@ RECAPTCHA_PUBLIC_KEY = '6LeYIbsSAAAAACRPIllxA7wvXjIE411PfdB2gt2J'
 RECAPTCHA_PRIVATE_KEY = '6LeYIbsSAAAAAJezaIq3Ft_hSTo0YtyeFG-JgRtu'
 
 
-class RecaptchaFrom(Form):
+class RecaptchaFrom(FlaskForm):
     SECRET_KEY = "a poorly kept secret."
     recaptcha = RecaptchaField()
 

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -8,7 +8,7 @@ except ImportError:
 from flask import render_template, request
 
 from wtforms import StringField, FieldList
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
 from flask_wtf.file import file_required, file_allowed
 
@@ -30,21 +30,21 @@ class UploadSet(object):
 images = UploadSet('images', ['jpg', 'png'])
 
 
-class FileUploadForm(Form):
+class FileUploadForm(FlaskForm):
     upload = FileField("Upload file")
 
 
-class MultipleFileUploadForm(Form):
+class MultipleFileUploadForm(FlaskForm):
     uploads = FieldList(FileField("upload"), min_entries=3)
 
 
-class ImageUploadForm(Form):
+class ImageUploadForm(FlaskForm):
     upload = FileField("Upload file",
                        validators=[file_required(),
                                    file_allowed(images)])
 
 
-class TextUploadForm(Form):
+class TextUploadForm(FlaskForm):
     upload = FileField("Upload file",
                        validators=[file_required(),
                                    file_allowed(['txt'])])
@@ -152,7 +152,7 @@ class TestFileUpload(TestCase):
         assert b'invalid' in response.data
 
 
-class BrokenForm(Form):
+class BrokenForm(FlaskForm):
     text_fields = FieldList(StringField())
     file_fields = FieldList(FileField())
 


### PR DESCRIPTION
Show deprecation warning when using `Form`.
closes #249