### PR TITLE
CSRF cleanup and fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,6 @@
 Developer Interface
 ===================
 
-This part of the documentation covers all interfaces of Flask-WTF.
-
 Forms and Fields
 ----------------
 
@@ -34,6 +32,9 @@ CSRF Protection
 .. module:: flask_wtf.csrf
 
 .. autoclass:: CsrfProtect
+   :members:
+
+.. autoclass:: CsrfError
    :members:
 
 .. autofunction:: generate_csrf

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,36 @@
 Flask-WTF Changelog
 ===================
 
+Version 0.14
+------------
+
+In development
+
+- Use itsdangerous to sign CSRF tokens and check expiration instead of doing it
+  ourselves. (`#264`_)
+
+    - All tokens are URL safe, removing the ``url_safe`` parameter from
+      ``generate_csrf``. (`#206`_)
+    - All tokens store a timestamp, which is checked in ``validate_csrf``. The
+      ``time_limit`` parameter of ``generate_csrf`` is removed.
+
+- Remove the ``app`` attribute from ``CsrfProtect``, use ``current_app``.
+  (`#264`_)
+- ``CsrfProtect`` protects the ``DELETE`` method by default. (`#264`_)
+- The same CSRF token is generated for the lifetime of a request. It is exposed
+  as ``request.csrf_token`` for use during testing. (`#227`_, `#264`_)
+- ``CsrfProtect.error_handler`` is deprecated. (`#264`_)
+    - Handlers that return a response work in addition to those that raise an
+      error. The behavior was not clear in previous docs.
+    - (`#200`_, `#209`_, `#243`_, `#252`_)
+
+.. _`#200`: https://github.com/lepture/flask-wtf/issues/200
+.. _`#209`: https://github.com/lepture/flask-wtf/pull/209
+.. _`#227`: https://github.com/lepture/flask-wtf/issues/227
+.. _`#243`: https://github.com/lepture/flask-wtf/pull/243
+.. _`#252`: https://github.com/lepture/flask-wtf/pull/252
+.. _`#264`: https://github.com/lepture/flask-wtf/pull/264
+
 Version 0.13.1
 --------------
 

--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -1,34 +1,26 @@
+.. module:: flask_wtf.csrf
+
+.. _csrf:
+
 CSRF Protection
 ===============
 
-This part of the documentation covers the CSRF protection.
+Any view using :class:`flask_wtf.FlaskForm` to process the request is already
+getting CSRF protection. If you have views that don't use ``FlaskForm`` or make
+AJAX requests, use the provided CSRF extension to protect those requests as
+well.
 
-Why CSRF
---------
+Setup
+-----
 
-Flask-WTF form is already protecting you from CSRF, you don't have to
-worry about that. However, you have views that contain no forms, and they
-still need protection.
-
-For example, the POST request is sent by AJAX, but it has no form behind
-it. You can't get the csrf token prior 0.9.0 of Flask-WTF. That's why we
-created this CSRF for you.
-
-Implementation
---------------
-
-.. module:: flask_wtf.csrf
-
-To enable CSRF protection for all your view handlers, you need to enable
-the :class:`CsrfProtect` module::
+To enable CSRF protection globally for a Flask app, register the
+:class:`CsrfProtect` extension. ::
 
     from flask_wtf.csrf import CsrfProtect
 
-    CsrfProtect(app)
+    csrf = CsrfProtect(app)
 
-Like any other Flask extensions, you can load it lazily::
-
-    from flask_wtf.csrf import CsrfProtect
+Like other Flask extensions, you can apply it lazily::
 
     csrf = CsrfProtect()
 
@@ -38,94 +30,86 @@ Like any other Flask extensions, you can load it lazily::
 
 .. note::
 
-    You need to setup a secret key for CSRF protection. Usually, this
-    is the same as your Flask app SECRET_KEY.
+    CSRF protection requires a secret key to securely sign the token. By default
+    this will use the Flask app's ``SECRET_KEY``. If you'd like to use a
+    separate token you can set ``WTF_CSRF_SECRET_KEY``.
 
-If the template has a form, you don't need to do any thing. It is the
-same as before:
+HTML Forms
+----------
+
+When using a ``FlaskForm``, render the form's CSRF field like normal.
 
 .. sourcecode:: html+jinja
 
-    <form method="post" action="/">
+    <form method="post">
         {{ form.csrf_token }}
     </form>
 
-But if the template has no forms, you still need a csrf token:
+If the template doesn't use a ``FlaskForm``, render a hidden input with the
+token in the form.
 
 .. sourcecode:: html+jinja
 
-    <form method="post" action="/">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
 
-Whenever a CSRF validation fails, it will return a 400 response. You can
-customize the error response::
+JavaScript Requests
+-------------------
 
-    @csrf.error_handler
-    def csrf_error(reason):
-        return render_template('csrf_error.html', reason=reason), 400
+When sending an AJAX request, add the ``X-CSRFToken`` header to it.
+For example, in jQuery you can configure all requests to send the token.
+
+.. sourcecode:: html+jinja
+
+    <script type="text/javascript">
+        var csrf_token = "{{ csrf_token() }}";
+
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
+                    xhr.setRequestHeader("X-CSRFToken", csrf_token);
+                }
+            }
+        });
+    </script>
+
+Customize the error response
+----------------------------
+
+When CSRF validation fails, it will raise a :class:`CsrfError`.
+By default this returns a response with the failure reason and a 400 code.
+You can customize the error response using Flask's
+:meth:`~flask.Flask.errorhandler`. ::
+
+    from flask_wtf.csrf import CsrfError
+
+    @app.errorhandler(CsrfError)
+    def handle_csrf_error(e):
+        return render_template('csrf_error.html', reason=e.description), 400
+
+Exclude views from protection
+-----------------------------
 
 We strongly suggest that you protect all your views with CSRF. But if
-needed, you can exclude some views using a decorator::
+needed, you can exclude some views using a decorator. ::
 
-    @csrf.exempt
     @app.route('/foo', methods=('GET', 'POST'))
+    @csrf.exempt
     def my_handler():
         # ...
         return 'ok'
 
-If needed, you can also exclude all the views from within a given Blueprint:
+You can exclude all the views of a blueprint. ::
 
     csrf.exempt(account_blueprint)
 
-You can also disable CSRF protection in all views by default, by setting
+You can disable CSRF protection in all views by default, by setting
 ``WTF_CSRF_CHECK_DEFAULT`` to ``False``, and selectively call
 ``csrf.protect()`` only when you need. This also enables you to do some
-pre-processing on the requests before checking for the CSRF token::
+pre-processing on the requests before checking for the CSRF token. ::
 
     @app.before_request
     def check_csrf():
         if not is_oauth(request):
             csrf.protect()
-
-AJAX
-----
-
-Sending POST requests via AJAX is possible where there are no forms at all.
-This feature is available since 0.9.0.
-
-Assuming you have done ``CsrfProtect(app)``, you can get the csrf token via
-``{{ csrf_token() }}``. This method is available in every template, that
-way you don't have to worry if there are no forms for rendering the csrf token
-field.
-
-The suggested way is that you render the token in a ``<meta>`` tag:
-
-.. sourcecode:: html+jinja
-
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-
-And it is also possible to render it in the ``<script>`` tag:
-
-.. sourcecode:: html+jinja
-
-    <script type="text/javascript">
-        var csrftoken = "{{ csrf_token() }}"
-    </script>
-
-We will take the ``<meta>`` way for example, the ``<script>`` way is far
-more easier, you don't have to worry if there is no example for it.
-
-Whenever you send a AJAX POST request, add the ``X-CSRFToken`` for it:
-
-.. sourcecode:: javascript
-
-    var csrftoken = $('meta[name=csrf-token]').attr('content')
-
-    $.ajaxSetup({
-        beforeSend: function(xhr, settings) {
-            if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                xhr.setRequestHeader("X-CSRFToken", csrftoken)
-            }
-        }
-    })

--- a/flask_wtf/_compat.py
+++ b/flask_wtf/_compat.py
@@ -6,9 +6,11 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
+    from urllib.parse import urlparse
 else:
     text_type = unicode
     string_types = (str, unicode)
+    from urlparse import urlparse
 
 
 def to_bytes(text):

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -207,7 +207,7 @@ class CsrfProtect(object):
         return view
 
     def _error_response(self, reason):
-        raise CSRFError(reason)
+        raise CsrfError(reason)
 
     def error_handler(self, view):
         """A decorator that set the error response handler.
@@ -223,18 +223,19 @@ class CsrfProtect(object):
 
         warnings.warn(FlaskWTFDeprecationWarning(
             '"@csrf.error_handler" is deprecated. Use the standard Flask error '
-            'system with "@app.errorhandler(CSRFError)" instead.'
+            'system with "@app.errorhandler(CsrfError)" instead.'
         ), stacklevel=2)
 
         @wraps(view)
         def handler(reason):
-            raise CSRFError(response=current_app.make_response(view(reason)))
+            response = current_app.make_response(view(reason))
+            raise CsrfError(response.get_data(as_text=True), response=response)
 
         self._error_response = handler
         return view
 
 
-class CSRFError(BadRequest):
+class CsrfError(BadRequest):
     description = 'CSRF token missing or incorrect.'
 
 

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -98,7 +98,9 @@ class CsrfProtect(object):
     def init_app(self, app):
         app.config.setdefault('WTF_CSRF_ENABLED', True)
         app.config.setdefault('WTF_CSRF_CHECK_DEFAULT', True)
-        app.config.setdefault('WTF_CSRF_METHODS', ['POST', 'PUT', 'PATCH'])
+        app.config['WTF_CSRF_METHODS'] = set(app.config.get(
+            'WTF_CSRF_METHODS', ['POST', 'PUT', 'PATCH', 'DELETE']
+        ))
         app.config.setdefault('WTF_CSRF_HEADERS', ['X-CSRFToken', 'X-CSRF-Token'])
         app.config.setdefault('WTF_CSRF_SSL_STRICT', True)
 
@@ -125,14 +127,13 @@ class CsrfProtect(object):
             if not view:
                 return
 
-            if self._exempt_views or self._exempt_blueprints:
-                dest = '%s.%s' % (view.__module__, view.__name__)
+            if request.blueprint in self._exempt_blueprints:
+                return
 
-                if dest in self._exempt_views:
-                    return
+            dest = '%s.%s' % (view.__module__, view.__name__)
 
-                if request.blueprint in self._exempt_blueprints:
-                    return
+            if dest in self._exempt_views:
+                return
 
             self.protect()
 

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -14,7 +14,6 @@ import warnings
 from functools import wraps
 
 from flask import Blueprint, current_app, request, session
-from flask import g
 from itsdangerous import BadData, URLSafeTimedSerializer
 from werkzeug.exceptions import BadRequest
 from werkzeug.security import safe_str_cmp
@@ -40,14 +39,14 @@ def generate_csrf(secret_key=None, token_key='csrf_token'):
     :param secret_key: A secret key for mixing in the token, default is ``Flask.secret_key``.
     """
 
-    if token_key not in g:
+    if not hasattr(request, 'csrf_token'):
         if token_key not in session:
             session[token_key] = hashlib.sha1(os.urandom(64)).hexdigest()
 
         s = URLSafeTimedSerializer(_get_secret_key(secret_key), salt='wtf-csrf-token')
-        setattr(g, token_key, s.dumps(session[token_key]))
+        request.csrf_token = s.dumps(session[token_key])
 
-    return getattr(g, token_key)
+    return request.csrf_token
 
 
 def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'):

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -45,14 +45,14 @@ def generate_csrf(secret_key=None, token_key='csrf_token'):
     :param token_key: key where token is stored in session for comparision.
     """
 
-    if not hasattr(request, 'csrf_token'):
+    if not getattr(request, token_key, None):
         if token_key not in session:
             session[token_key] = hashlib.sha1(os.urandom(64)).hexdigest()
 
         s = URLSafeTimedSerializer(_get_secret_key(secret_key), salt='wtf-csrf-token')
-        request.csrf_token = s.dumps(session[token_key])
+        setattr(request, token_key, s.dumps(session[token_key]))
 
-    return request.csrf_token
+    return getattr(request, token_key)
 
 
 def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'):

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -8,14 +8,15 @@
     :copyright: (c) 2013 by Hsiaoming Yang.
 """
 
-import os
-import hmac
 import hashlib
-import time
-from flask import Blueprint
-from flask import current_app, session, request, abort
+import os
+
+from flask import Blueprint, abort, current_app, request, session
+from itsdangerous import BadData, URLSafeTimedSerializer
 from werkzeug.security import safe_str_cmp
-from ._compat import to_bytes, string_types
+
+from ._compat import string_types
+
 try:
     from urlparse import urlparse
 except ImportError:
@@ -26,46 +27,31 @@ except ImportError:
 __all__ = ('generate_csrf', 'validate_csrf', 'CsrfProtect')
 
 
-def generate_csrf(secret_key=None, time_limit=None, token_key='csrf_token', url_safe=False):
-    """Generate csrf token code.
+def _get_secret_key(secret_key=None):
+    if not secret_key:
+        secret_key = current_app.config.get('WTF_CSRF_SECRET_KEY', current_app.secret_key)
 
-    :param secret_key: A secret key for mixing in the token,
-                       default is Flask.secret_key.
-    :param time_limit: Token valid in the time limit,
-                       default is 3600s.
+    if not secret_key:
+        raise Exception('Must provide secret_key to use CSRF.')
+
+    return secret_key
+
+
+def generate_csrf(secret_key=None, token_key='csrf_token'):
+    """Generate CSRF token code.
+
+    :param secret_key: A secret key for mixing in the token, default is ``Flask.secret_key``.
     """
-    if not secret_key:
-        secret_key = current_app.config.get(
-            'WTF_CSRF_SECRET_KEY', current_app.secret_key
-        )
-
-    if not secret_key:
-        raise Exception('Must provide secret_key to use csrf.')
-
-    if time_limit is None:
-        time_limit = current_app.config.get('WTF_CSRF_TIME_LIMIT', 3600)
 
     if token_key not in session:
         session[token_key] = hashlib.sha1(os.urandom(64)).hexdigest()
 
-    if time_limit:
-        expires = int(time.time() + time_limit)
-        csrf_build = '%s%s' % (session[token_key], expires)
-    else:
-        expires = ''
-        csrf_build = session[token_key]
-
-    hmac_csrf = hmac.new(
-        to_bytes(secret_key),
-        to_bytes(csrf_build),
-        digestmod=hashlib.sha1
-    ).hexdigest()
-    delimiter = '--' if url_safe else '##'
-    return '%s%s%s' % (expires, delimiter, hmac_csrf)
+    s = URLSafeTimedSerializer(_get_secret_key(secret_key), salt='wtf-csrf-token')
+    return s.dumps(session[token_key])
 
 
-def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token', url_safe=False):
-    """Check if the given data is a valid csrf token.
+def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'):
+    """Check if the given data is a valid CSRF token.
 
     :param data: The csrf token value to be checked.
     :param secret_key: A secret key for mixing in the token,
@@ -73,44 +59,21 @@ def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'
     :param time_limit: Check if the csrf token is expired.
                        default is True.
     """
-    delimiter = '--' if url_safe else '##'
-    if not data or delimiter not in data:
+
+    if not data or token_key not in session:
         return False
 
-    try:
-        expires, hmac_csrf = data.split(delimiter, 1)
-    except ValueError:
-        return False  # unpack error
+    s = URLSafeTimedSerializer(_get_secret_key(secret_key), salt='wtf-csrf-token')
 
     if time_limit is None:
         time_limit = current_app.config.get('WTF_CSRF_TIME_LIMIT', 3600)
 
-    if time_limit:
-        try:
-            expires = int(expires)
-        except ValueError:
-            return False
-
-        now = int(time.time())
-        if now > expires:
-            return False
-
-    if not secret_key:
-        secret_key = current_app.config.get(
-            'WTF_CSRF_SECRET_KEY', current_app.secret_key
-        )
-
-    if token_key not in session:
+    try:
+        token = s.loads(data, max_age=time_limit)
+    except BadData:
         return False
 
-    csrf_build = '%s%s' % (session[token_key], expires)
-    hmac_compare = hmac.new(
-        to_bytes(secret_key),
-        to_bytes(csrf_build),
-        digestmod=hashlib.sha1
-    ).hexdigest()
-
-    return safe_str_cmp(hmac_compare, hmac_csrf)
+    return safe_str_cmp(session[token_key], token)
 
 
 class CsrfProtect(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,12 @@
 from __future__ import with_statement
 
-from flask import Flask, render_template, jsonify
-from wtforms import StringField, HiddenField, SubmitField
-from wtforms.validators import DataRequired
+from unittest import TestCase as _TestCase
+
+from flask import Flask, jsonify, render_template
 from flask_wtf import FlaskForm
 from flask_wtf._compat import text_type
+from wtforms import HiddenField, StringField, SubmitField
+from wtforms.validators import DataRequired
 
 
 def to_unicode(text):
@@ -37,7 +39,7 @@ class SimpleForm(FlaskForm):
     pass
 
 
-class TestCase(object):
+class TestCase(_TestCase):
     def setUp(self):
         self.app = self.create_app()
         self.client = self.app.test_client()

--- a/tests/templates/csrf_macro.html
+++ b/tests/templates/csrf_macro.html
@@ -1,3 +1,3 @@
 {% macro render_csrf_token() %}
-  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input name="csrf_token" type="hidden" value="{{ csrf_token() }}">
 {% endmacro %}

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -6,7 +6,7 @@ import warnings
 from flask import Blueprint, render_template
 from flask import abort
 from flask_wtf._compat import FlaskWTFDeprecationWarning
-from flask_wtf.csrf import CSRFError, CsrfProtect, generate_csrf, validate_csrf
+from flask_wtf.csrf import CsrfError, CsrfProtect, generate_csrf, validate_csrf
 
 from .base import MyForm, TestCase, to_unicode
 
@@ -60,7 +60,7 @@ class TestCSRF(TestCase):
         response = self.client.post("/", data={"name": "danny"})
         assert response.status_code == 400
 
-        @self.app.errorhandler(CSRFError)
+        @self.app.errorhandler(CsrfError)
         def handle_csrf_error(e):
             return e, 200
 
@@ -190,7 +190,7 @@ class TestCSRF(TestCase):
         response = self.client.post("/csrf-protect-method", data={"name": "danny"})
         assert response.status_code == 400
 
-        @self.app.errorhandler(CSRFError)
+        @self.app.errorhandler(CsrfError)
         def handle_csrf_error(e):
             return e, 200
 
@@ -308,7 +308,7 @@ class TestCSRF(TestCase):
 
             self.assertEqual(len(w), 1)
             assert issubclass(w[0].category, FlaskWTFDeprecationWarning)
-            assert 'app.errorhandler(CSRFError)' in str(w[0].message)
+            assert 'app.errorhandler(CsrfError)' in str(w[0].message)
 
             rv = self.client.post('/', data={'name': 'david'})
             assert b'caught csrf return' in rv.data
@@ -322,7 +322,7 @@ class TestCSRF(TestCase):
 
             self.assertEqual(len(w), 1)
             assert issubclass(w[0].category, FlaskWTFDeprecationWarning)
-            assert 'app.errorhandler(CSRFError)' in str(w[0].message)
+            assert 'app.errorhandler(CsrfError)' in str(w[0].message)
 
             rv = self.client.post('/', data={'name': 'david'})
             assert b'caught csrf abort' in rv.data

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,7 +10,6 @@ csrf_token_input = re.compile(
 
 
 def get_csrf_token(data):
-    print(data)
     match = csrf_token_input.search(to_unicode(data))
     assert match
     return match.groups()[0]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,11 +5,12 @@ import re
 from .base import TestCase, MyForm, to_unicode
 
 csrf_token_input = re.compile(
-    r'name="csrf_token" type="hidden" value="([0-9a-z#A-Z-\.]*)"'
+    r'name="csrf_token" type="hidden" value="([0-9a-zA-Z\-._]*)"'
 )
 
 
 def get_csrf_token(data):
+    print(data)
     match = csrf_token_input.search(to_unicode(data))
     assert match
     return match.groups()[0]


### PR DESCRIPTION
- Use itsdangerous to sign tokens and check expiration, instead of rolling our own.
    - All tokens are url safe, essentially reverting #206.  There is no longer a `url_safe` parameter. cc @twolfson 
    - All tokens store a timstamp, which is checked in `validate_csrf`.  There is no longer a `time_limit` parameter to `generate_csrf`.
- Fix anti-pattern of storing `app` on extension, use `current_app` when needed.
- Add the `DELETE` method as protected by default.
- Generate the same signed token over the lifetime of a request. Exposed as `request.csrf_token`. (#227)
- `@csrf.error_handler` is deprecated in favor of the standard Flask error system `@app.errorhandler(CSRFError)`.
    - decorator is "fixed" so that it handles both raising an exception or returning a response.  A returned response is converted into a raised exception, which is handled by Flask.
    - addresses #200, #209, #243, #252