### PR TITLE
Switch to Form.Meta from SecureForm, improve CSRF errors

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ CSRF Protection
 .. autoclass:: CsrfProtect
    :members:
 
-.. autoclass:: CsrfError
+.. autoclass:: CSRFError
    :members:
 
 .. autofunction:: generate_csrf

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,8 +31,10 @@ CSRF Protection
 
 .. module:: flask_wtf.csrf
 
-.. autoclass:: CsrfProtect
+.. autoclass:: CSRFProtect
    :members:
+
+.. autoclass:: CsrfProtect(...)
 
 .. autoclass:: CSRFError
    :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,16 +20,33 @@ In development
 - The same CSRF token is generated for the lifetime of a request. It is exposed
   as ``request.csrf_token`` for use during testing. (`#227`_, `#264`_)
 - ``CsrfProtect.error_handler`` is deprecated. (`#264`_)
+
     - Handlers that return a response work in addition to those that raise an
       error. The behavior was not clear in previous docs.
     - (`#200`_, `#209`_, `#243`_, `#252`_)
 
+- Use ``Form.Meta`` instead of deprecated ``SecureForm`` for CSRF (and
+  everything else). (`#216`_, `#271`_)
+
+    - ``csrf_enabled`` parameter is still recognized but deprecated. All other
+      attributes and methods from ``SecureForm`` are removed. (`#271`_)
+
+- Provide ``WTF_CSRF_FIELD_NAME`` to configure the name of the CSRF token.
+  (`#271`_)
+- ``CsrfError`` is renamed to ``CSRFError``. (`#271`_)
+- ``validate_csrf`` raises ``wtforms.ValidationError`` with specifc messages
+  instead of returning ``True`` or ``False``. This breaks anything that was
+  calling the method directly. (`#239`_, `#271`_)
+
 .. _`#200`: https://github.com/lepture/flask-wtf/issues/200
 .. _`#209`: https://github.com/lepture/flask-wtf/pull/209
+.. _`#216`: https://github.com/lepture/flask-wtf/issues/216
 .. _`#227`: https://github.com/lepture/flask-wtf/issues/227
+.. _`#239`: https://github.com/lepture/flask-wtf/issues/239
 .. _`#243`: https://github.com/lepture/flask-wtf/pull/243
 .. _`#252`: https://github.com/lepture/flask-wtf/pull/252
 .. _`#264`: https://github.com/lepture/flask-wtf/pull/264
+.. _`#271`: https://github.com/lepture/flask-wtf/pull/271
 
 Version 0.13.1
 --------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,12 +33,15 @@ In development
 
 - Provide ``WTF_CSRF_FIELD_NAME`` to configure the name of the CSRF token.
   (`#271`_)
-- ``CsrfError`` is renamed to ``CSRFError``. (`#271`_)
 - ``validate_csrf`` raises ``wtforms.ValidationError`` with specific messages
   instead of returning ``True`` or ``False``. This breaks anything that was
   calling the method directly. (`#239`_, `#271`_)
 
     - CSRF errors are logged as well as raised. (`#239`_)
+
+- ``CsrfProtect`` is renamed to ``CSRFProtect``. A deprecation warning is issued
+  when using the old name. ``CsrfError`` is renamed to ``CSRFError`` without
+  deprecation. (`#271`_)
 
 .. _`#200`: https://github.com/lepture/flask-wtf/issues/200
 .. _`#209`: https://github.com/lepture/flask-wtf/pull/209

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,9 +34,11 @@ In development
 - Provide ``WTF_CSRF_FIELD_NAME`` to configure the name of the CSRF token.
   (`#271`_)
 - ``CsrfError`` is renamed to ``CSRFError``. (`#271`_)
-- ``validate_csrf`` raises ``wtforms.ValidationError`` with specifc messages
+- ``validate_csrf`` raises ``wtforms.ValidationError`` with specific messages
   instead of returning ``True`` or ``False``. This breaks anything that was
   calling the method directly. (`#239`_, `#271`_)
+
+    - CSRF errors are logged as well as raised. (`#239`_)
 
 .. _`#200`: https://github.com/lepture/flask-wtf/issues/200
 .. _`#209`: https://github.com/lepture/flask-wtf/pull/209

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -35,3 +35,10 @@ Recaptcha
                           https://www.google.com/recaptcha/admin/create
 ``RECAPTCHA_OPTIONS``     **optional** A dict of configuration options.
 ========================= ==============================================
+
+Logging
+-------
+
+CSRF errors are logged at the ``INFO`` level to the ``flask_wtf.csrf`` logger.
+You still need to configure logging in your application in order to see these
+messages.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,47 +1,37 @@
 Configuration
 =============
 
-Here is the full table of all configurations.
-
-Forms and CSRF
---------------
-
-The full list of configuration for Flask-WTF. Usually, you don't need
-to configure any of them. It just works.
-
-======================= ==============================================
-WTF_CSRF_ENABLED        Disable/enable CSRF protection for forms.
-                        Default is True.
-WTF_CSRF_CHECK_DEFAULT  Enable CSRF checks for all views by default.
-                        Default is True.
-WTF_I18N_ENABLED        Disable/enable I18N support. This should work
-                        together with Flask-Babel. Default is True.
-WTF_CSRF_HEADERS        CSRF token HTTP headers checked. Default is
-                        **['X-CSRFToken', 'X-CSRF-Token']**
-WTF_CSRF_SECRET_KEY     A random string for generating CSRF token.
-                        Default is the same as SECRET_KEY.
-WTF_CSRF_TIME_LIMIT     CSRF token expiring time. Default is **3600**
-                        seconds. If set to ``None``, the CSRF token
-                        is then bound to the life-time of the session.
-WTF_CSRF_SSL_STRICT     Strictly protection on SSL. This will check
-                        the referrer, validate if it is from the same
-                        origin. Default is True.
-WTF_CSRF_METHODS        CSRF protection on these request methods.
-                        Default is **['POST', 'PUT', 'PATCH']**
-======================= ==============================================
-
+========================== =====================================================
+``WTF_CSRF_ENABLED``       Set to ``False`` to disable all CSRF protection.
+``WTF_CSRF_CHECK_DEFAULT`` When using the CSRF protection extension, this
+                           controls whether every view is protected by default.
+                           Default is ``True``.
+``WTF_CSRF_SECRET_KEY``    Random data for generating secure tokens. If this is
+                           not set then ``SECRET_KEY`` is used.
+``WTF_CSRF_METHODS``       HTTP methods to protect from CSRF. Default is
+                           ``{'POST', 'PUT', 'PATCH', 'DELETE'}``.
+``WTF_CSRF_FIELD_NAME``    Name of the form field and session key that holds the
+                           CSRF token.
+``WTF_CSRF_HEADERS``       HTTP headers to search for CSRF token when it is not
+                           provided in the form. Default is
+                           ``['X-CSRFToken', 'X-CSRF-Token']``.
+``WTF_CSRF_TIME_LIMIT``    Max age in seconds for CSRF tokens. Default is
+                           ``3600``. If set to ``None``, the CSRF token is valid
+                           for the life of the session.
+``WTF_CSRF_SSL_STRICT``    Whether to enforce the same origin policy by checking
+                           that the referrer matches the host. Only applies to
+                           HTTPS requests. Default is ``True``.
+``WTF_I18N_ENABLED``       Set to ``False`` to disable Flask-Babel I18N support.
+========================== =====================================================
 
 Recaptcha
 ---------
 
-You have already learned these configuration at :ref:`recaptcha`.
-This table is only designed for a convience.
-
-======================= ==============================================
-RECAPTCHA_USE_SSL       Enable/disable recaptcha through ssl.
-                        Default is False.
-RECAPTCHA_PUBLIC_KEY    **required** A public key.
-RECAPTCHA_PRIVATE_KEY   **required** A private key.
-RECAPTCHA_OPTIONS       **optional** A dict of configuration options.
-                        https://www.google.com/recaptcha/admin/create
-======================= ==============================================
+========================= ==============================================
+``RECAPTCHA_USE_SSL``     Enable/disable recaptcha through SSL. Default is
+                          ``False``.
+``RECAPTCHA_PUBLIC_KEY``  **required** A public key.
+``RECAPTCHA_PRIVATE_KEY`` **required** A private key.
+                          https://www.google.com/recaptcha/admin/create
+``RECAPTCHA_OPTIONS``     **optional** A dict of configuration options.
+========================= ==============================================

--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -5,7 +5,7 @@
 CSRF Protection
 ===============
 
-Any view using :class:`flask_wtf.FlaskForm` to process the request is already
+Any view using :class:`~flask_wtf.FlaskForm` to process the request is already
 getting CSRF protection. If you have views that don't use ``FlaskForm`` or make
 AJAX requests, use the provided CSRF extension to protect those requests as
 well.
@@ -14,15 +14,15 @@ Setup
 -----
 
 To enable CSRF protection globally for a Flask app, register the
-:class:`CsrfProtect` extension. ::
+:class:`CSRFProtect` extension. ::
 
-    from flask_wtf.csrf import CsrfProtect
+    from flask_wtf.csrf import CSRFProtect
 
-    csrf = CsrfProtect(app)
+    csrf = CSRFProtect(app)
 
 Like other Flask extensions, you can apply it lazily::
 
-    csrf = CsrfProtect()
+    csrf = CSRFProtect()
 
     def create_app():
         app = Flask(__name__)
@@ -82,7 +82,7 @@ By default this returns a response with the failure reason and a 400 code.
 You can customize the error response using Flask's
 :meth:`~flask.Flask.errorhandler`. ::
 
-    from flask_wtf.csrf import CsrfError
+    from flask_wtf.csrf import CSRFError
 
     @app.errorhandler(CsrfError)
     def handle_csrf_error(e):
@@ -106,7 +106,7 @@ You can exclude all the views of a blueprint. ::
 
 You can disable CSRF protection in all views by default, by setting
 ``WTF_CSRF_CHECK_DEFAULT`` to ``False``, and selectively call
-``csrf.protect()`` only when you need. This also enables you to do some
+:meth:`~flask_wtf.csrf.CSRFProtect.protect` only when you need. This also enables you to do some
 pre-processing on the requests before checking for the CSRF token. ::
 
     @app.before_request

--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -77,7 +77,7 @@ For example, in jQuery you can configure all requests to send the token.
 Customize the error response
 ----------------------------
 
-When CSRF validation fails, it will raise a :class:`CsrfError`.
+When CSRF validation fails, it will raise a :class:`CSRFError`.
 By default this returns a response with the failure reason and a 400 code.
 You can customize the error response using Flask's
 :meth:`~flask.Flask.errorhandler`. ::

--- a/flask_wtf/__init__.py
+++ b/flask_wtf/__init__.py
@@ -12,7 +12,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 
-from .csrf import CsrfProtect
+from .csrf import CSRFProtect, CsrfProtect
 from .form import FlaskForm, Form
 from .recaptcha import *
 

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -13,7 +13,7 @@ from wtforms.csrf.core import CSRF
 
 from ._compat import FlaskWTFDeprecationWarning, string_types, urlparse
 
-__all__ = ('generate_csrf', 'validate_csrf', 'CsrfProtect')
+__all__ = ('generate_csrf', 'validate_csrf', 'CSRFProtect')
 logger = logging.getLogger(__name__)
 
 
@@ -147,7 +147,7 @@ class _FlaskFormCSRF(CSRF):
             raise
 
 
-class CsrfProtect(object):
+class CSRFProtect(object):
     """Enable CSRF protection globally for a Flask app.
 
     ::
@@ -322,6 +322,20 @@ class CsrfProtect(object):
 
         self._error_response = handler
         return view
+
+
+class CsrfProtect(CSRFProtect):
+    """
+    .. deprecated:: 0.14
+        Renamed to :class:`~flask_wtf.csrf.CSRFProtect`.
+    """
+
+    def __init__(self, app=None):
+        warnings.warn(FlaskWTFDeprecationWarning(
+            '"flask_wtf.CsrfProtect" has been renamed to "CSRFProtect" '
+            'and will be removed in 1.0.'
+        ), stacklevel=2)
+        super(CsrfProtect, self).__init__(app=app)
 
 
 class CSRFError(BadRequest):

--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -1,122 +1,93 @@
-# coding: utf-8
 import warnings
 
-from flask import current_app, request, session
+from flask import current_app, request
+from flask import session
 from jinja2 import Markup
-from werkzeug.datastructures import MultiDict
-from wtforms.ext.csrf.form import SecureForm
-from wtforms.validators import ValidationError
+from werkzeug.datastructures import CombinedMultiDict, ImmutableMultiDict
+from wtforms import Form
+from wtforms.meta import DefaultMeta
 from wtforms.widgets import HiddenInput
 
 from ._compat import FlaskWTFDeprecationWarning, string_types, text_type
-from .csrf import generate_csrf, validate_csrf
+from .csrf import _FlaskFormCSRF
 
 try:
     from .i18n import translations
 except ImportError:
     translations = None  # babel not installed
 
+
 SUBMIT_METHODS = set(('POST', 'PUT', 'PATCH', 'DELETE'))
+_Auto = object()
 
 
-class _Auto(object):
-    """Placeholder for unspecified variables that should be set to defaults.
+class FlaskForm(Form):
+    """Flask-specific subclass of WTForms :class:`~wtforms.form.Form`.
 
-    Used when None is a valid option and should not be replaced by a default.
-    """
-    pass
-
-
-class FlaskForm(SecureForm):
-    """Flask-specific subclass of WTForms :class:`~wtforms.ext.csrf.form.SecureForm` class.
-
-    If ``formdata`` is not specified, this will use :attr:`flask.request.form` and
-    :attr:`flask.request.files`.  Explicitly pass ``formdata=None`` to prevent this.
-
-    :param csrf_context: a session or dict-like object to use when making
-        CSRF tokens. Default: :data:`flask.session`.
-
-    :param secret_key: a secret key for building CSRF tokens. If this isn't
-        specified, the form will take the first of these
-        that is defined:
-
-        * SECRET_KEY attribute on this class
-        * WTF_CSRF_SECRET_KEY config of Flask app
-        * SECRET_KEY config of Flask app
-        * session secret key
-
-    :param csrf_enabled: whether to use CSRF protection. If False, all
-        csrf behavior is suppressed.
-        Default: WTF_CSRF_ENABLED config value
+    If ``formdata`` is not specified, this will use :attr:`flask.request.form`
+    and :attr:`flask.request.files`.  Explicitly pass ``formdata=None`` to
+    prevent this.
     """
 
-    SECRET_KEY = None
-    TIME_LIMIT = None
+    class Meta(DefaultMeta):
+        csrf_class = _FlaskFormCSRF
+        csrf_context = session  # not used, provided for custom csrf_class
 
-    def __init__(self, formdata=_Auto, obj=None, prefix='', csrf_context=None,
-                 secret_key=None, csrf_enabled=None, **kwargs):
+        def __init__(self):
+            config = current_app.config.get
+            self.csrf = config('WTF_CSRF_ENABLED', True)
+            self.csrf_secret = config(
+                'WTF_CSRF_SECRET_KEY', current_app.secret_key
+            )
+            self.csrf_field_name = config('WTF_CSRF_FIELD_NAME', 'csrf_token')
+            self.csrf_time_limit = config('WTF_CSRF_TIME_LIMIT', 3600)
 
-        if csrf_enabled is None:
-            csrf_enabled = current_app.config.get('WTF_CSRF_ENABLED', True)
+        def wrap_formdata(self, form, formdata):
+            if formdata is _Auto:
+                if _is_submitted():
+                    if request.files:
+                        return CombinedMultiDict((
+                            request.files, request.form
+                        ))
+                    elif request.form:
+                        return request.form
+                    elif request.get_json():
+                        return ImmutableMultiDict(request.get_json())
 
-        self.csrf_enabled = csrf_enabled
+                return None
 
-        if formdata is _Auto:
-            if self.is_submitted():
-                formdata = request.form
-                if request.files:
-                    formdata = formdata.copy()
-                    formdata.update(request.files)
-                elif request.get_json():
-                    formdata = MultiDict(request.get_json())
-            else:
-                formdata = None
+            return formdata
 
-        if self.csrf_enabled:
-            if csrf_context is None:
-                csrf_context = session
-            if secret_key is None:
-                # It wasn't passed in, check if the class has a SECRET_KEY
-                secret_key = getattr(self, "SECRET_KEY", None)
+        def get_translations(self, form):
+            if not current_app.config.get('WTF_I18N_ENABLED', True):
+                return None
 
-            self.SECRET_KEY = secret_key
-        else:
-            csrf_context = {}
-            self.SECRET_KEY = ''
-        super(FlaskForm, self).__init__(
-            formdata, obj, prefix,
-            csrf_context=csrf_context,
-            **kwargs
-        )
+            return translations
 
-    def generate_csrf_token(self, csrf_context=None):
-        if not self.csrf_enabled:
-            return None
+    def __init__(self, formdata=_Auto, **kwargs):
+        csrf_enabled = kwargs.pop('csrf_enabled', None)
 
-        return generate_csrf(secret_key=self.SECRET_KEY)
+        if csrf_enabled is not None:
+            warnings.warn(FlaskWTFDeprecationWarning(
+                '"csrf_enabled" is deprecated and will be removed in 1.0. '
+                'Set "meta.csrf" instead.'
+            ), stacklevel=3)
+            kwargs.setdefault('meta', {}).setdefault('csrf', csrf_enabled)
 
-    def validate_csrf_token(self, field):
-        if not self.csrf_enabled:
-            return True
-
-        if getattr(request, 'csrf_valid', False):
-            # this is validated by CsrfProtect
-            return True
-
-        if not self.validate_csrf_data(field.data):
-            raise ValidationError(field.gettext('CSRF token missing'))
-
-    def validate_csrf_data(self, data):
-        """Check if the given data is a valid CSRF token."""
-
-        return validate_csrf(data, secret_key=self.SECRET_KEY, time_limit=self.TIME_LIMIT)
+        super(FlaskForm, self).__init__(formdata=formdata, **kwargs)
 
     def is_submitted(self):
         """Consider the form submitted if there is an active request and
         the method is ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
         """
 
-        return request and request.method in SUBMIT_METHODS
+        return _is_submitted()
+
+    def validate_on_submit(self):
+        """Call :meth:`validate` only if the form is submitted.
+        This is a shortcut for ``form.is_submitted() and form.validate()``.
+        """
+        return self.is_submitted() and self.validate()
 
     def hidden_tag(self, *fields):
         """Render the form's hidden fields in one call.
@@ -149,26 +120,17 @@ class FlaskForm(SecureForm):
 
                 yield f
 
-        return Markup(u'\n'.join(text_type(f) for f in hidden_fields(fields or self)))
+        return Markup(
+            u'\n'.join(text_type(f) for f in hidden_fields(fields or self))
+        )
 
-    def validate_on_submit(self):
-        """Call :meth:`validate` only if the form is submitted.
-        This is a shortcut for ``form.is_submitted() and form.validate()``.
-        """
-        return self.is_submitted() and self.validate()
 
-    @property
-    def data(self):
-        d = super(FlaskForm, self).data
-        # https://github.com/lepture/flask-wtf/issues/208
-        if self.csrf_enabled:
-            d.pop('csrf_token', None)
-        return d
+def _is_submitted():
+    """Consider the form submitted if there is an active request and
+    the method is ``POST``, ``PUT``, ``PATCH``, or ``DELETE``.
+    """
 
-    def _get_translations(self):
-        if not current_app.config.get('WTF_I18N_ENABLED', True):
-            return None
-        return translations
+    return bool(request) and request.method in SUBMIT_METHODS
 
 
 class Form(FlaskForm):

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,9 @@
 from __future__ import with_statement
 
+from contextlib import contextmanager
 from unittest import TestCase as _TestCase
 
+import logging
 from flask import Flask, jsonify, render_template
 from wtforms import HiddenField, StringField, SubmitField
 from wtforms.validators import DataRequired
@@ -38,6 +40,35 @@ class HiddenFieldsForm(FlaskForm):
 class SimpleForm(FlaskForm):
     SECRET_KEY = "a poorly kept secret."
     pass
+
+
+class CaptureHandler(logging.Handler):
+    def __init__(self):
+        self.records = []
+        logging.Handler.__init__(self, logging.DEBUG)
+
+    def emit(self, record):
+        self.records.append(record)
+
+    def __iter__(self):
+        return iter(self.records)
+
+    def __len__(self):
+        return len(self.records)
+
+    def __getitem__(self, item):
+        return self.records[item]
+
+
+@contextmanager
+def capture_logging(logger):
+    handler = CaptureHandler()
+
+    try:
+        logger.addHandler(handler)
+        yield handler
+    finally:
+        logger.removeHandler(handler)
 
 
 class TestCase(_TestCase):

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,10 +3,11 @@ from __future__ import with_statement
 from unittest import TestCase as _TestCase
 
 from flask import Flask, jsonify, render_template
-from flask_wtf import FlaskForm
-from flask_wtf._compat import text_type
 from wtforms import HiddenField, StringField, SubmitField
 from wtforms.validators import DataRequired
+
+from flask_wtf import FlaskForm
+from flask_wtf._compat import text_type
 
 
 def to_unicode(text):
@@ -65,18 +66,18 @@ class TestCase(_TestCase):
         def simple():
             form = SimpleForm()
             form.validate()
-            assert form.csrf_enabled
+            assert form.meta.csrf
             assert not form.validate()
             return "OK"
 
         @app.route("/two_forms/", methods=("POST",))
         def two_forms():
             form = SimpleForm()
-            assert form.csrf_enabled
+            assert form.meta.csrf
             assert form.validate()
             assert form.validate()
             form2 = SimpleForm()
-            assert form2.csrf_enabled
+            assert form2.meta.csrf
             assert form2.validate()
             return "OK"
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -7,7 +7,7 @@ from flask import Blueprint, abort, render_template, request
 from wtforms import ValidationError
 
 from flask_wtf._compat import FlaskWTFDeprecationWarning
-from flask_wtf.csrf import CSRFError, CsrfProtect, generate_csrf, validate_csrf
+from flask_wtf.csrf import CSRFError, CSRFProtect, generate_csrf, validate_csrf
 from .base import MyForm, TestCase
 
 
@@ -15,7 +15,7 @@ class TestCSRF(TestCase):
     def setUp(self):
         app = self.create_app()
         app.config['WTF_CSRF_SECRET_KEY'] = "a poorly kept secret."
-        csrf = CsrfProtect(app)
+        csrf = CSRFProtect(app)
         self.csrf = csrf
 
         @csrf.exempt

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -4,11 +4,11 @@ from unittest import TestCase
 from wtforms.compat import with_metaclass
 from wtforms.form import FormMeta
 
-from flask_wtf import FlaskForm, Form
+from flask_wtf import CsrfProtect, FlaskForm, Form
 from flask_wtf._compat import FlaskWTFDeprecationWarning
 
 
-class TestForm(TestCase):
+class TestDeprecated(TestCase):
     def test_deprecated_form(self):
         with warnings.catch_warnings():
             warnings.simplefilter('error', FlaskWTFDeprecationWarning)
@@ -38,3 +38,8 @@ class TestForm(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter('error', FlaskWTFDeprecationWarning)
             self.assertRaises(FlaskWTFDeprecationWarning, F, csrf_enabled=False)
+
+    def test_deprecated_csrfprotect(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', FlaskWTFDeprecationWarning)
+            self.assertRaises(FlaskWTFDeprecationWarning, CsrfProtect)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,9 +1,11 @@
 import warnings
 from unittest import TestCase
-from flask_wtf import Form
-from flask_wtf._compat import FlaskWTFDeprecationWarning
+
 from wtforms.compat import with_metaclass
 from wtforms.form import FormMeta
+
+from flask_wtf import FlaskForm, Form
+from flask_wtf._compat import FlaskWTFDeprecationWarning
 
 
 class TestForm(TestCase):
@@ -28,3 +30,11 @@ class TestForm(TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter('error', FlaskWTFDeprecationWarning)
             self.assertRaises(FlaskWTFDeprecationWarning, __import__, 'flask_wtf.html5')
+
+    def test_deprecated_csrf_enabled(self):
+        class F(FlaskForm):
+            pass
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', FlaskWTFDeprecationWarning)
+            self.assertRaises(FlaskWTFDeprecationWarning, F, csrf_enabled=False)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -5,7 +5,7 @@ from .base import TestCase, to_unicode
 
 class TestI18NCase(TestCase):
     def test_i18n_disabled(self):
-        self.app.config['CSRF_ENABLED'] = False
+        self.app.config['WTF_CSRF_ENABLED'] = False
         response = self.client.post(
             "/",
             headers={'Accept-Language': 'zh-CN,zh;q=0.8'},
@@ -22,7 +22,7 @@ class TestI18NCase(TestCase):
         def get_locale():
             return request.accept_languages.best_match(['en', 'zh'], 'en')
 
-        self.app.config['CSRF_ENABLED'] = False
+        self.app.config['WTF_CSRF_ENABLED'] = False
 
         response = self.client.post(
             "/",

--- a/tests/test_recaptcha.py
+++ b/tests/test_recaptcha.py
@@ -1,10 +1,10 @@
 from __future__ import with_statement
 
-from .base import TestCase
-from flask import json
-from flask import Flask, render_template
+from flask import Flask, json, render_template
+
 from flask_wtf import FlaskForm
 from flask_wtf.recaptcha import RecaptchaField
+from .base import TestCase
 
 
 RECAPTCHA_PUBLIC_KEY = '6LeYIbsSAAAAACRPIllxA7wvXjIE411PfdB2gt2J'
@@ -25,7 +25,7 @@ class TestRecaptcha(TestCase):
 
         @app.route("/", methods=("GET", "POST"))
         def index():
-            form = RecaptchaFrom(csrf_enabled=False)
+            form = RecaptchaFrom(meta={'csrf': False})
             if form.validate_on_submit():
                 return 'OK'
             return render_template("recaptcha.html", form=form)

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -170,7 +170,7 @@ class TestFileList(TestCase):
             assert len(request.files)  # the files have been added to the
                                        # request
 
-            f = BrokenForm(csrf_enabled=False)
+            f = BrokenForm(meta={'csrf': False})
 
             assert f.validate_on_submit()
             assert len(text_data) == len(f.text_fields)


### PR DESCRIPTION
- Use `Form.Meta` instead of deprecated `SecureForm` for CSRF (and
  everything else). (#216)
    - `csrf_enabled` parameter is still recognized but deprecated.
    - All other attributes and methods from `SecureForm` are removed. **This breaks anything using them.** These were really just side effects of `SecureForm`, so I didn't try to deprecate everything as no one should really have been using those parts in the first place.
- Provide `WTF_CSRF_FIELD_NAME` to configure the name of the CSRF token.
- `validate_csrf` raises `wtforms.ValidationError` with specific messages
  instead of returning `True` or `False`. **This breaks anything that was
  calling the method directly.**
    - CSRF errors are logged as well as raised. (#239)
    - I tried, but could not come up with a sane way to deprecate the old behavior. I'd rather keep moving towards 1.0 than bog this down with crazy deprecation logic at each step.
- `CsrfProtect` is renamed to `CSRFProtect`, with a deprecation warning.
    - `CsrfError` is renamed to `CSRFError` for consistency, but without a deprecation warning since it's relatively new and internal.