### PR TITLE
Deprecate FileField

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,8 +19,7 @@ Forms and Fields
 
 .. module:: flask_wtf.file
 
-.. autoclass:: FileField
-   :members:
+.. autoclass:: FileField(...)
 
 .. autoclass:: FileAllowed
 
@@ -32,12 +31,12 @@ CSRF Protection
 .. module:: flask_wtf.csrf
 
 .. autoclass:: CSRFProtect
-   :members:
+    :members:
 
 .. autoclass:: CsrfProtect(...)
 
 .. autoclass:: CSRFError
-   :members:
+    :members:
 
 .. autofunction:: generate_csrf
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,8 @@ In development
 - ``CsrfProtect`` is renamed to ``CSRFProtect``. A deprecation warning is issued
   when using the old name. ``CsrfError`` is renamed to ``CSRFError`` without
   deprecation. (`#271`_)
+- ``FileField`` is deprecated because it no longer provides functionality over
+  the provided validators. Use ``wtforms.FileField`` directly.
 
 .. _`#200`: https://github.com/lepture/flask-wtf/issues/200
 .. _`#209`: https://github.com/lepture/flask-wtf/pull/209

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import warnings
 from datetime import datetime
 
 from pkg_resources import get_distribution
@@ -340,5 +339,6 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'flask': ('http://flask.pocoo.org/docs/latest/', None),
     'werkzeug': ('http://werkzeug.pocoo.org/docs/latest/', None),
-    'wtforms': ('https://wtforms.readthedocs.io/en/latest/', None)
+    'wtforms': ('https://wtforms.readthedocs.io/en/latest/', None),
+    'flask_uploads': ('https://pythonhosted.org/Flask-Uploads', None),
 }

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -30,27 +30,6 @@ File Uploads
 
 .. module:: flask_wtf.file
 
-Flask-WTF provides :class:`FileField` to handle file uploading.
-It automatically draws data from ``flask.request.files`` when the form
-is posted. The field's ``data`` attribute is an instance of
-:class:`~werkzeug.datastructures.FileStorage`. ::
-
-    from werkzeug.utils import secure_filename
-    from flask_wtf.file import FileField
-
-    class PhotoForm(FlaskForm):
-        photo = FileField('Your photo')
-
-    @app.route('/upload/', methods=('GET', 'POST'))
-    def upload():
-        form = PhotoForm()
-        if form.validate_on_submit():
-            filename = secure_filename(form.photo.data.filename)
-            form.photo.data.save('uploads/' + filename)
-        else:
-            filename = None
-        return render_template('upload.html', form=form, filename=filename)
-
 Remember to set the ``enctype`` of the HTML form to
 ``multipart/form-data``, otherwise ``request.files`` will be empty.
 

--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -1,15 +1,28 @@
+import warnings
+
+from collections import Iterable
 from werkzeug.datastructures import FileStorage
 from wtforms import FileField as _FileField
-from wtforms.validators import InputRequired, StopValidation
+from wtforms.validators import DataRequired, StopValidation
+
+from flask_wtf._compat import FlaskWTFDeprecationWarning
 
 
 class FileField(_FileField):
     """
     Werkzeug-aware subclass of **wtforms.FileField**
 
-    Provides a `has_file()` method to check if its data is a FileStorage
-    instance with an actual file.
+    .. deprecated:: 0.14
+        ``has_file`` was simplified and merged into the validators.
+        This subclass is no longer needed and will be removed in 1.0.
     """
+
+    def __new__(cls, *args, **kwargs):
+        warnings.warn(FlaskWTFDeprecationWarning(
+            'The "FileField" subclass is no longer necessary and will be '
+            'removed in 1.0. Use "wtforms.FileField" directly instead.'
+        ), stacklevel=2)
+        return super(FileField, cls).__new__(cls, *args, **kwargs)
 
     def has_file(self):
         """Return True if self.data is a
@@ -18,36 +31,36 @@ class FileField(_FileField):
         return isinstance(self.data, FileStorage)
 
 
-class FileRequired(InputRequired):
-    """
-    Validates that field has a file.
+class FileRequired(DataRequired):
+    """Validates that the data is a Werkzeug
+    :class:`~werkzeug.datastructures.FileStorage` object.
 
     :param message: error message
 
-    You can also use the synonym **file_required**.
+    You can also use the synonym ``file_required``.
     """
 
     def __call__(self, form, field):
-        if not field.has_file():
+        if not isinstance(field.data, FileStorage):
             if self.message is None:
                 message = field.gettext('This field is required.')
             else:
                 message = self.message
+
             raise StopValidation(message)
 
 file_required = FileRequired
 
 
 class FileAllowed(object):
-    """
-    Validates that the uploaded file is allowed by the given
-    Flask-Uploads UploadSet.
+    """Validates that the uploaded file is allowed by a given list of
+    extensions or a Flask-Uploads :class:`~flaskext.uploads.UploadSet`.
 
-    :param upload_set: A list/tuple of extention names or an instance
-                       of ``flask_uploads.UploadSet``
+    :param upload_set: A list of extensions or an
+        :class:`~flaskext.uploads.UploadSet`
     :param message: error message
 
-    You can also use the synonym **file_allowed**.
+    You can also use the synonym ``file_allowed``.
     """
 
     def __init__(self, upload_set, message=None):
@@ -55,21 +68,22 @@ class FileAllowed(object):
         self.message = message
 
     def __call__(self, form, field):
-        if not field.has_file():
+        if not isinstance(field.data, FileStorage):
             return
 
         filename = field.data.filename.lower()
 
-        if isinstance(self.upload_set, (tuple, list)):
+        if isinstance(self.upload_set, Iterable):
             if any(filename.endswith('.' + x) for x in self.upload_set):
                 return
-            message = (
-                'File does not end with any of the allowed extentions: {}'
-            ).format(self.upload_set)
-            raise StopValidation(self.message or message)
+
+            raise StopValidation(self.message or field.gettext(
+                'File does not have an approved extension: {extensions}'
+            ).format(extensions=', '.join(self.upload_set)))
 
         if not self.upload_set.file_allowed(field.data, filename):
-            raise StopValidation(self.message or
-                                 'File does not have an approved extension')
+            raise StopValidation(self.message or field.gettext(
+                'File does not have an approved extension.'
+            ))
 
 file_allowed = FileAllowed


### PR DESCRIPTION
Move the remainder of `has_file` into the two decorators, since it's only an instance check now. Use the decorators with WTForms' normal `FileField`.