### PR TITLE
Fix forms & csrf_enabled deprecation doc

### DIFF
--- a/docs/form.rst
+++ b/docs/form.rst
@@ -11,7 +11,7 @@ form with csrf protection. We encourage you do nothing.
 
 But if you want to disable the csrf protection, you can pass::
 
-    form = FlaskForm(meta={'csrf_enabled': False})
+    form = FlaskForm(meta={'csrf': False})
 
 You can disable it globally—though you really shouldn't—with the
 configuration::

--- a/docs/form.rst
+++ b/docs/form.rst
@@ -11,7 +11,7 @@ form with csrf protection. We encourage you do nothing.
 
 But if you want to disable the csrf protection, you can pass::
 
-    form = FlaskForm(csrf_enabled=False)
+    form = FlaskForm(meta={'csrf_enabled': False})
 
 You can disable it globally—though you really shouldn't—with the
 configuration::

--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -79,7 +79,7 @@ class FlaskForm(Form):
         if csrf_enabled is not None:
             warnings.warn(FlaskWTFDeprecationWarning(
                 '"csrf_enabled" is deprecated and will be removed in 1.0. '
-                'Set "meta.csrf" instead.'
+                "Pass meta={'csrf': False} instead."
             ), stacklevel=3)
             kwargs['meta'] = kwargs.get('meta') or {}
             kwargs['meta'].setdefault('csrf', csrf_enabled)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -132,4 +132,4 @@ def test_deprecated_csrf_enabled(req_ctx, recwarn):
 
     F(csrf_enabled=False)
     w = recwarn.pop(FlaskWTFDeprecationWarning)
-    assert 'meta.csrf' in str(w.message)
+    assert "meta={'csrf': False}" in str(w.message)


### PR DESCRIPTION
I had hard times understanding the deprecation of `csrf_enabled`. The only way I managed to do it was by reading *form.py*. 

Let's make the doc and deprecation message better :-)