### PR TITLE
Allow users to use WTF I18N internationalisations directly

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -70,7 +70,8 @@ class FlaskForm(Form):
         def get_translations(self, form):
             if not current_app.config.get('WTF_I18N_ENABLED', True):
                 return None
-
+            if current_app.config.get('FLASKWTF_USE_WTF_I18N', False):
+                return super().get_translations(form)
             return translations
 
     def __init__(self, formdata=_Auto, **kwargs):


### PR DESCRIPTION
Hey guys, was trying to use the internationalisations provided by wtforms and could not do it using FlaskForm. This pull request allows FLASK-WTF users to add a parameter (FLASKWTF_USE_WTFI18N) in their config files, allowing them to use the internationalisations provided for wtforms

Thank you for this amazing repo.