### PR TITLE
Modified as a set expression standard

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -17,7 +17,7 @@ except ImportError:
     translations = None  # babel not installed
 
 
-SUBMIT_METHODS = set(('POST', 'PUT', 'PATCH', 'DELETE'))
+SUBMIT_METHODS = {'POST', 'PUT', 'PATCH', 'DELETE'}
 _Auto = object()
 
 


### PR DESCRIPTION
This expression is warned by pycharm. Replace  set (('POST', 'PUT', 'PATCH', 'DELETE') with {'DELETE', 'PATCH', 'POST', 'PUT'}