### PR TITLE
Include itsdangerous dependency in install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'Flask',
         'WTForms',
+        'itsdangerous'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Since flask-wtf directly uses the itsdangerous dependency in [csrf.py](https://github.com/lepture/flask-wtf/blob/master/flask_wtf/csrf.py) it should be included in setup.py.