### PR TITLE
Attempts to add max file size validation. Tests fail on python 2.X. N…

### DIFF
--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -91,3 +91,33 @@ class FileAllowed(object):
 
 
 file_allowed = FileAllowed
+
+class FileMaxSize(object):
+    """Validates that the uploaded file is within a maximum file size given in bytes
+
+    :param max_size: maximum file size given in kilobytes
+    :param message: error message
+
+    You can also use the synonym ``file_max_size``.
+    """
+
+    def __init__(self, max_size, message=None):
+        self.max_size = max_size
+        self.message = message
+
+    def __call__(self, form, field):
+        if not (isinstance(field.data, FileStorage) and field.data):
+            return
+
+        file_size = len(field.data.read()) / 1024  # read the file to determine its size and convert from bytes to Kb
+        field.data.seek(0)  # reset cursor position to beginning of file
+
+        if file_size <= self.max_size:
+            return
+        else:  # the file is too big => validation failure
+            raise StopValidation(self.message or field.gettext(
+                'File should be smaller than ' + str(self.max_size) + ' Kb.'
+            ))
+
+
+file_max_size = FileMaxSize


### PR DESCRIPTION
_Obligatory disclaimer: I'm absolutely new to this and am very much an amateur programmer. It's my first pull request. The very little I know is flaky, so I'm 100% open to constructive criticism on code and/or contributing etiquette._

A while ago I opened [this issue](https://github.com/lepture/flask-wtf/issues/307) where I suggested adding file size validation. I received no reply, so I thought I would try to do it. I'm convinced this is not the best approach, but hopefully I can get the ball rolling.
Before someone says it, I'm aware one can configure MAX_CONTENT_LENGTH, but:

- I imagine there are instances where one may want to avoid returning a 413
- This would allow setting different max file sizes per form, instead of for the whole flask application.

Onto the pull:
I've tried adding file size validation and its pertaining tests. In my tests it works on python 3.X, but I cannot make it work on python 2.X and I cannot figure out why. Can anyone provide guidance?