### PR TITLE
Add support to change message language

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -22,14 +22,7 @@ Configuration
                            that the referrer matches the host. Only applies to
                            HTTPS requests. Default is ``True``.
 ``WTF_I18N_ENABLED``       Set to ``False`` to disable Flask-Babel I18N support.
-``WTF_MESSAGE_LANGUAGE``   The default language for error messages. Default is 
-                           ``None`` (English). The values will be a list of 
-                           languages by priority to use, e.g: ``['es_ES', 'es']``.
-                           The full list of support locale can be found in here_.
-                           Set this will disabled i18n.
 ========================== =====================================================
-
-.. _here: https://github.com/wtforms/wtforms/tree/master/wtforms/locale
 
 Recaptcha
 ---------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -22,7 +22,14 @@ Configuration
                            that the referrer matches the host. Only applies to
                            HTTPS requests. Default is ``True``.
 ``WTF_I18N_ENABLED``       Set to ``False`` to disable Flask-Babel I18N support.
+``WTF_MESSAGE_LANGUAGE``   The default language for error messages. Default is 
+                           ``None`` (English). The values will be a list of 
+                           languages by priority to use, e.g: ``['es_ES', 'es']``.
+                           The full list of support locale can be found in here_.
+                           Set this will disabled i18n.
 ========================== =====================================================
+
+.. _here: https://github.com/wtforms/wtforms/tree/master/wtforms/locale
 
 Recaptcha
 ---------

--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -68,6 +68,11 @@ class FlaskForm(Form):
             return formdata
 
         def get_translations(self, form):
+            locales = current_app.config.get('WTF_MESSAGE_LANGUAGE', None)
+            if locales is not None:
+                self.locales = locales
+                return super(FlaskForm.Meta, self).get_translations(form)
+
             if not current_app.config.get('WTF_I18N_ENABLED', True):
                 return None
 

--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -68,13 +68,8 @@ class FlaskForm(Form):
             return formdata
 
         def get_translations(self, form):
-            locales = current_app.config.get('WTF_MESSAGE_LANGUAGE', None)
-            if locales is not None:
-                self.locales = locales
-                return super(FlaskForm.Meta, self).get_translations(form)
-
             if not current_app.config.get('WTF_I18N_ENABLED', True):
-                return None
+                return super(FlaskForm.Meta, self).get_translations(form)
 
             return translations
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -147,9 +147,17 @@ def test_set_default_message_language(app, client):
 
     @app.route('/es', methods=['POST'])
     def es():
-        app.config['WTF_MESSAGE_LANGUAGE'] = ['es']
+        app.config['WTF_I18N_ENABLED'] = False
 
-        form = BasicForm()
+        class MyBaseForm(FlaskForm):
+            class Meta:
+                csrf = False
+                locales = ['es']
+
+        class NameForm(MyBaseForm):
+            name = StringField(validators=[DataRequired()])
+
+        form = NameForm()
         assert form.meta.locales == ['es']
         assert not form.validate_on_submit()
         assert 'Este campo es obligatorio.' in form.name.errors

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -133,3 +133,25 @@ def test_deprecated_csrf_enabled(req_ctx, recwarn):
     F(csrf_enabled=False)
     w = recwarn.pop(FlaskWTFDeprecationWarning)
     assert "meta={'csrf': False}" in str(w.message)
+
+
+def test_set_default_message_language(app, client):
+
+    @app.route('/default', methods=['POST'])
+    def default():
+        form = BasicForm()
+        assert not form.validate_on_submit()
+        assert 'This field is required.' in form.name.errors
+
+    client.post('/default', data={'name': '  '})
+
+    @app.route('/es', methods=['POST'])
+    def es():
+        app.config['WTF_MESSAGE_LANGUAGE'] = ['es']
+
+        form = BasicForm()
+        assert form.meta.locales == ['es']
+        assert not form.validate_on_submit()
+        assert 'Este campo es obligatorio.' in form.name.errors
+
+    client.post('/es', data={'name': '  '})


### PR DESCRIPTION
With this PR, people can change the built-in error message's default language.

- [x] Test added
- [x] Documentation updated 

Address #303 and #300.