### PR TITLE
Validation view decorators

### DIFF
--- a/examples/validates/app.py
+++ b/examples/validates/app.py
@@ -1,0 +1,27 @@
+from flask import Flask
+from flask import render_template
+from flask_wtf import current_form
+from flask_wtf import validates
+from wtforms import StringField
+from wtforms import SubmitField
+from wtforms import TextAreaField
+from wtforms.validators import DataRequired
+
+
+DEBUG = True
+SECRET_KEY = "secret"
+
+app = Flask(__name__)
+app.config.from_object(__name__)
+
+
+@app.route("/", methods=("GET", "POST",))
+@validates(title=StringField("Title", validators=[DataRequired()]),
+           text=TextAreaField("Text"),
+           submit=SubmitField("Create"))
+def index():
+    return render_template("index.html", form=current_form)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/examples/validates/templates/index.html
+++ b/examples/validates/templates/index.html
@@ -1,0 +1,24 @@
+<html>
+  <body>
+    <form method="POST" action="{{ url_for('index') }}">
+      {{ form.csrf_token }}
+      <p>
+        {{ form.title.label }}<br>
+        {{ form.title() }}
+        {% for error in form.title.errors %}
+          {{ error }}
+        {% endfor %}
+      </p>
+      <p>
+        {{ form.text.label }}<br>
+        {{ form.text(rows=5, cols=40) }}
+        {% for error in form.text.errors %}
+          {{ error }}
+        {% endfor %}
+      </p>
+      <p>
+        {{ form.submit() }}
+      </p>
+    </form>
+  </body>
+</html>

--- a/flask_wtf/__init__.py
+++ b/flask_wtf/__init__.py
@@ -3,5 +3,6 @@ from __future__ import absolute_import
 from .csrf import CSRFProtect, CsrfProtect
 from .form import FlaskForm, Form
 from .recaptcha import *
+from .validates import *
 
 __version__ = '0.15'

--- a/flask_wtf/validates.py
+++ b/flask_wtf/validates.py
@@ -1,0 +1,38 @@
+from functools import wraps
+
+from flask import _app_ctx_stack as stack
+from werkzeug.local import LocalProxy
+
+from .form import FlaskForm
+
+
+def validates(form_cls=None, **fields):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            ctx = stack.top
+            if ctx is not None:
+                ctx.current_form = _make_form(form_cls, **fields)
+                ctx.current_form.validate_on_submit()
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
+
+def _make_form(form_cls, **fields):
+    if form_cls is not None:
+        cls = type("_DynamicForm_%s" % form_cls.__name__, (form_cls,), fields)
+    else:
+        cls = type("_DynamicForm", (FlaskForm,), fields)
+    return cls()
+
+
+def _current_form():
+    ctx = stack.top
+    if not hasattr(ctx, "current_form"):
+        return None
+    else:
+        return ctx.current_form
+
+
+current_form = LocalProxy(_current_form)

--- a/tests/test_validates.py
+++ b/tests/test_validates.py
@@ -1,0 +1,39 @@
+from wtforms import StringField
+from wtforms import TextAreaField
+from wtforms.validators import DataRequired
+
+from flask_wtf import FlaskForm
+from flask_wtf import current_form
+from flask_wtf import validates
+
+
+class BasicForm(FlaskForm):
+    name = StringField(validators=[DataRequired()])
+
+
+def test_validates_with_form_class(app, client):
+    @app.route("/", methods=["POST"])
+    @validates(BasicForm)
+    def index():
+        assert current_form.name.data == "form"
+
+    client.post("/", data=dict(name="form"))
+
+
+def test_validates_with_form_class_and_fields(app, client):
+    @app.route("/", methods=["POST"])
+    @validates(BasicForm, text=TextAreaField("text"))
+    def index():
+        assert current_form.name.data == "name"
+        assert current_form.text.data == "text"
+
+    client.post("/", data=dict(name="name", text="text"))
+
+
+def test_validates_with_fields_only(app, client):
+    @app.route("/", methods=["POST"])
+    @validates(name=StringField(validators=[DataRequired()]))
+    def index():
+        assert current_form.name.data == "name"
+
+    client.post("/", data=dict(name="name"))


### PR DESCRIPTION
This PR adds support for form validation using decorators which provide an alternative means of handling form validation.

## Motivation

There are three scenarios I can envisage view decorators being particularly useful.

### Validation for smaller sets of fields

```python
@app.route("/tweets", methods=["POST"])
@validates(body=StringField("Body", validators=[DataRequired(), Length(max=140)])
def create():
    ...
```

### Ad hoc addition of fields to existing forms

```python
@app.route("/tweets", methods=["POST"])
@validates(TweetForm, recaptcha=RecaptchaField())
def create():
    ...
```

### Reducing boilerplate

```python
@app.route("/api/tweets", methods=["POST"])
@validates(TweetForm)
def create():
    if not current_form.errors:
        ....
```

The code as it stands lacks documentation and as such should be considered a WIP. My main reason for opening this now is to get feedback and a sense of whether this would be a useful addition to flask-wtf.