### PR TITLE
Quickstart: methods param for /submit route should be [], not ()

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -52,7 +52,7 @@ Validating Forms
 
 Validating the request in your view handlers::
 
-    @app.route('/submit', methods=('GET', 'POST'))
+    @app.route('/submit', methods=['GET', 'POST'])
     def submit():
         form = MyForm()
         if form.validate_on_submit():


### PR DESCRIPTION
Clearly a typo, would cause `405 Method Not Allowed`.
Please let me know if you need an issue raised for this, thanks.