### PR TITLE
Fix Sphinx deprecation warning, requires Sphinx 1.6.6

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,10 +166,10 @@ html_static_path = ['_static']
 #
 # html_last_updated_fmt = None
 
-# If true, SmartyPants will be used to convert quotes and dashes to
+# If true, Smart Quotes will be used to convert quotes and dashes to
 # typographically correct entities.
 #
-html_use_smartypants = False
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 #


### PR DESCRIPTION
Otherwise recent Sphinx versions display the following warning:
```
RemovedInSphinx17Warning: html_use_smartypants option is deprecated
```
See http://www.sphinx-doc.org/en/1.6.7/config.html#confval-smartquotes