### PR TITLE
Update imports for werkzeug==0.16.0

### DIFF
--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -7,7 +7,7 @@ except ImportError:
 import json
 
 from flask import current_app, request
-from werkzeug import url_encode
+from werkzeug.urls import url_encode
 from wtforms import ValidationError
 
 from .._compat import to_bytes, to_unicode

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask import Markup, current_app, json
-from werkzeug import url_encode
+from werkzeug.urls import url_encode
 
 JSONEncoder = json.JSONEncoder
 


### PR DESCRIPTION
Addresses Issue #377 

`werkzeug==0.16.0` started giving the following deprecation warning:
    The import 'werkzeug.url_encode' is deprecated and will be removed in Werkzeug 1.0.
    Use 'from werkzeug.urls import url_encode' instead.

