### PR TITLE
Fix deprecation warning

### DIFF
--- a/flask_wtf/_compat.py
+++ b/flask_wtf/_compat.py
@@ -6,10 +6,12 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
+    from collections.abc import Iterable
     from urllib.parse import urlparse
 else:
     text_type = unicode
     string_types = (str, unicode)
+    from collections import Iterable
     from urlparse import urlparse
 
 

--- a/flask_wtf/_compat.py
+++ b/flask_wtf/_compat.py
@@ -6,12 +6,12 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
-    from collections.abc import Iterable
+    from collections import abc
     from urllib.parse import urlparse
 else:
     text_type = unicode
     string_types = (str, unicode)
-    from collections import Iterable
+    import collections as abc
     from urlparse import urlparse
 
 

--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -1,11 +1,15 @@
 import warnings
-from collections.abc import Iterable
 
 from werkzeug.datastructures import FileStorage
 from wtforms import FileField as _FileField
 from wtforms.validators import DataRequired, StopValidation
 
 from ._compat import FlaskWTFDeprecationWarning
+from ._compat import PY2
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 
 class FileField(_FileField):

--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -5,11 +5,7 @@ from wtforms import FileField as _FileField
 from wtforms.validators import DataRequired, StopValidation
 
 from ._compat import FlaskWTFDeprecationWarning
-from ._compat import PY2
-if PY2:
-    from collections import Iterable
-else:
-    from collections.abc import Iterable
+from ._compat import Iterable
 
 
 class FileField(_FileField):

--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -4,8 +4,8 @@ from werkzeug.datastructures import FileStorage
 from wtforms import FileField as _FileField
 from wtforms.validators import DataRequired, StopValidation
 
+from ._compat import abc
 from ._compat import FlaskWTFDeprecationWarning
-from ._compat import Iterable
 
 
 class FileField(_FileField):
@@ -76,7 +76,7 @@ class FileAllowed(object):
 
         filename = field.data.filename.lower()
 
-        if isinstance(self.upload_set, Iterable):
+        if isinstance(self.upload_set, abc.Iterable):
             if any(filename.endswith('.' + x) for x in self.upload_set):
                 return
 

--- a/flask_wtf/file.py
+++ b/flask_wtf/file.py
@@ -1,5 +1,5 @@
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 
 from werkzeug.datastructures import FileStorage
 from wtforms import FileField as _FileField


### PR DESCRIPTION
Iterable should be imported from collections.abc instead of from
collections.

modified:   flask_wtf/file.py