### PR TITLE
Add locales as a property to FlaskForm.Meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ _build
 .idea/
 htmlcov/
 .cache/
+.vscode/

--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -12,7 +12,7 @@ from ._compat import FlaskWTFDeprecationWarning, string_types, text_type
 from .csrf import _FlaskFormCSRF
 
 try:
-    from .i18n import translations
+    from .i18n import translations, get_locale
 except ImportError:
     translations = None  # babel not installed
 
@@ -32,6 +32,13 @@ class FlaskForm(Form):
     class Meta(DefaultMeta):
         csrf_class = _FlaskFormCSRF
         csrf_context = session  # not used, provided for custom csrf_class
+
+        @property
+        def locales(self):
+            if not current_app.config.get('WTF_I18N_ENABLED', True):
+                return False
+            locale = get_locale()
+            return [locale.language]
 
         @cached_property
         def csrf(self):


### PR DESCRIPTION
Further to issue #398, I propose to solve this issue by adding a `locales` property to `FlaskForm.Meta`. This property dynamically retrieves the current locale by calling `i18n.get_locale`. This allows `DecimalField` to render a localized form of the input value.

What I don't like about this solution is that the `Locale` object returned by `get_locale` needs to be converted to a language string only to be reassembled into a `Locale` object later by `babel` through `DecimalField._format_decimal`. 