### PR TITLE
Remove obsolete `sudo` keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 
 python:


### PR DESCRIPTION
cf. https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration