### PR TITLE
Fix Flask 2.0+ deprecation warning related to using jinja2.Markup, now it uses markupsafe.Markup

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -1,7 +1,7 @@
 import warnings
 
 from flask import current_app, request, session
-from jinja2 import Markup
+from markupsafe import Markup
 from werkzeug.datastructures import CombinedMultiDict, ImmutableMultiDict
 from werkzeug.utils import cached_property
 from wtforms import Form


### PR DESCRIPTION
Hi,

I recently updated a project to use Flask 2.0 which came with Jinja 3.0 as a dependency.

After doing that upgrade I started to get this warning from Flask-WTF:

```
python3.9/site-packages/flask_wtf/form.py:133: DeprecationWarning: 'jinja2.Markup' is deprecated
and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.
    return Markup(
```

This PR takes that advice and imports `Markup` from `markupsafe` instead of `jinja2`.