### PR TITLE
Fix docs typo

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -71,7 +71,7 @@ would look like this:
 
     {% if form.name.errors %}
         <ul class="errors">
-        {% for error in form.name %}
+        {% for error in form.name.errors %}
             <li>{{ error }}</li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
Original code example raises TypeError: 'StringField' object is not iterable