### PR TITLE
 CSRF meta tag helper

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,3 +39,5 @@ CSRF Protection
 .. autofunction:: generate_csrf
 
 .. autofunction:: validate_csrf
+
+.. autofunction:: csrf_meta_tag

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Unreleased
 - Allow setting a ``nonce`` on :class:`~flask_wtf.recaptcha.RecaptchaField`
   (string or zero-argument callable) for nonce-based Content Security
   Policies. :pr:`312`
+- Add ``csrf_meta_tag()`` helper and ``WTF_CSRF_META_NAME`` setting to render
+  the CSRF token as an HTML ``<meta>`` tag.
 
 Version 1.2.2
 -------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -16,6 +16,9 @@ Configuration
 ``WTF_CSRF_HEADERS``       HTTP headers to search for CSRF token when it is not
                            provided in the form. Default is
                            ``['X-CSRFToken', 'X-CSRF-Token']``.
+``WTF_CSRF_META_NAME``     Value of the ``name`` attribute rendered by
+                           :func:`~flask_wtf.csrf.csrf_meta_tag`. Default is
+                           ``csrf-token``.
 ``WTF_CSRF_TIME_LIMIT``    Max age in seconds for CSRF tokens. Default is
                            ``3600``. If set to ``None``, the CSRF token is valid
                            for the life of the session.

--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -61,33 +61,51 @@ token in the form.
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     </form>
 
+HTML Meta Tag
+-------------
+
+For JavaScript clients, the recommended way to expose the token to the page is
+to render it in a ``<meta>`` tag in the document ``<head>``. This is the
+convention used by Rails and recommended by the
+`OWASP CSRF prevention cheat sheet`_.
+
+.. sourcecode:: html+jinja
+
+    <head>
+        {{ csrf_meta_tag() }}
+    </head>
+
+This renders ``<meta name="csrf-token" content="...">``. The attribute name is
+configurable via the ``WTF_CSRF_META_NAME`` setting, or per-call with the
+``name`` argument: ``{{ csrf_meta_tag(name="authenticity-token") }}``.
+
+.. _OWASP CSRF prevention cheat sheet: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#storing-the-csrf-token-value-in-the-dom
+
 JavaScript Requests
 -------------------
 
-When sending an AJAX request, add the ``X-CSRFToken`` header to it.
-For example, in jQuery you can configure all requests to send the token.
+When sending an AJAX request, read the token from the meta tag and send it in
+the ``X-CSRFToken`` header. This pattern is compatible with a strict
+``Content-Security-Policy`` since no inline script is required.
 
-.. sourcecode:: html+jinja
+Using ``fetch``:
 
-    <script type="text/javascript">
-        var csrf_token = "{{ csrf_token() }}";
+.. sourcecode:: javascript
 
-        $.ajaxSetup({
-            beforeSend: function(xhr, settings) {
-                if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
-                    xhr.setRequestHeader("X-CSRFToken", csrf_token);
-                }
-            }
-        });
-    </script>
+    const token = document.querySelector('meta[name="csrf-token"]').content;
 
-In Axios you can set the header for all requests with ``axios.defaults.headers.common``.
+    fetch("/api/resource", {
+        method: "POST",
+        headers: { "X-CSRFToken": token, "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+    });
 
-.. sourcecode:: html+jinja
+Using Axios, configure the default header once at startup:
 
-    <script type="text/javascript">
-        axios.defaults.headers.common["X-CSRFToken"] = "{{ csrf_token() }}";
-    </script>
+.. sourcecode:: javascript
+
+    axios.defaults.headers.common["X-CSRFToken"] =
+        document.querySelector('meta[name="csrf-token"]').content;
 
 Customize the error response
 ----------------------------

--- a/src/flask_wtf/csrf.py
+++ b/src/flask_wtf/csrf.py
@@ -12,11 +12,13 @@ from flask import session
 from itsdangerous import BadData
 from itsdangerous import SignatureExpired
 from itsdangerous import URLSafeTimedSerializer
+from markupsafe import escape
+from markupsafe import Markup
 from werkzeug.exceptions import BadRequest
 from wtforms import ValidationError
 from wtforms.csrf.core import CSRF
 
-__all__ = ("generate_csrf", "validate_csrf", "CSRFProtect")
+__all__ = ("generate_csrf", "validate_csrf", "csrf_meta_tag", "CSRFProtect")
 logger = logging.getLogger(__name__)
 
 
@@ -115,6 +117,25 @@ def validate_csrf(data, secret_key=None, time_limit=None, token_key=None):
         raise ValidationError("The CSRF tokens do not match.")
 
 
+def csrf_meta_tag(name=None, secret_key=None, token_key=None):
+    """Render an HTML ``<meta>`` tag carrying the CSRF token, following the
+    convention used by Rails and recommended by OWASP for SPA and AJAX clients.
+
+    Extract the token client-side with
+    ``document.querySelector('meta[name="csrf-token"]').content`` and send it
+    in the ``X-CSRFToken`` header of state-changing requests.
+
+    :param name: Value of the meta tag's ``name`` attribute. Default is
+        ``WTF_CSRF_META_NAME`` or ``'csrf-token'``.
+    :param secret_key: Forwarded to :func:`generate_csrf`.
+    :param token_key: Forwarded to :func:`generate_csrf`.
+    """
+
+    name = _get_config(name, "WTF_CSRF_META_NAME", "csrf-token")
+    token = generate_csrf(secret_key=secret_key, token_key=token_key)
+    return Markup(f'<meta name="{escape(name)}" content="{escape(token)}">')
+
+
 def _get_config(
     value, config_name, default=None, required=True, message="CSRF is not configured."
 ):
@@ -197,11 +218,15 @@ class CSRFProtect:
         )
         app.config.setdefault("WTF_CSRF_FIELD_NAME", "csrf_token")
         app.config.setdefault("WTF_CSRF_HEADERS", ["X-CSRFToken", "X-CSRF-Token"])
+        app.config.setdefault("WTF_CSRF_META_NAME", "csrf-token")
         app.config.setdefault("WTF_CSRF_TIME_LIMIT", 3600)
         app.config.setdefault("WTF_CSRF_SSL_STRICT", True)
 
         app.jinja_env.globals["csrf_token"] = generate_csrf
-        app.context_processor(lambda: {"csrf_token": generate_csrf})
+        app.jinja_env.globals["csrf_meta_tag"] = csrf_meta_tag
+        app.context_processor(
+            lambda: {"csrf_token": generate_csrf, "csrf_meta_tag": csrf_meta_tag}
+        )
 
         @app.before_request
         def csrf_protect():

--- a/tests/test_csrf_extension.py
+++ b/tests/test_csrf_extension.py
@@ -4,6 +4,7 @@ from flask import g
 from flask import render_template_string
 
 from flask_wtf import FlaskForm
+from flask_wtf.csrf import csrf_meta_tag
 from flask_wtf.csrf import CSRFError
 from flask_wtf.csrf import CSRFProtect
 from flask_wtf.csrf import generate_csrf
@@ -33,6 +34,47 @@ def csrf(app):
 def test_render_token(req_ctx):
     token = generate_csrf()
     assert render_template_string("{{ csrf_token() }}") == token
+
+
+def test_csrf_meta_tag_default(req_ctx):
+    token = generate_csrf()
+    rendered = csrf_meta_tag()
+    assert rendered == f'<meta name="csrf-token" content="{token}">'
+
+
+def test_csrf_meta_tag_custom_name_param(req_ctx):
+    token = generate_csrf()
+    rendered = csrf_meta_tag(name="x-csrf")
+    assert rendered == f'<meta name="x-csrf" content="{token}">'
+
+
+def test_csrf_meta_tag_config(app, req_ctx):
+    app.config["WTF_CSRF_META_NAME"] = "authenticity-token"
+    token = generate_csrf()
+    rendered = csrf_meta_tag()
+    assert rendered == f'<meta name="authenticity-token" content="{token}">'
+
+
+def test_csrf_meta_tag_param_overrides_config(app, req_ctx):
+    app.config["WTF_CSRF_META_NAME"] = "from-config"
+    token = generate_csrf()
+    rendered = csrf_meta_tag(name="from-param")
+    assert rendered == f'<meta name="from-param" content="{token}">'
+
+
+def test_csrf_meta_tag_jinja(req_ctx):
+    token = generate_csrf()
+    assert (
+        render_template_string("{{ csrf_meta_tag() }}")
+        == f'<meta name="csrf-token" content="{token}">'
+    )
+
+
+def test_csrf_meta_tag_escapes_name(req_ctx):
+    token = generate_csrf()
+    rendered = csrf_meta_tag(name='"><script>alert(1)</script>')
+    assert "<script>" not in rendered
+    assert f'content="{token}"' in rendered
 
 
 def test_protect(app, client, app_ctx):


### PR DESCRIPTION
- add a helper to generate csrf meta tag following [owasp recommandations](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#storing-the-csrf-token-value-in-the-dom)
- update the doc so examples use modern JS instead of jQuery


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
