### PR TITLE
docs(csrf): clarify that CSRFProtect raises CSRFError, not forms

### DIFF
--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -115,10 +115,10 @@ Using Axios, configure the default header once at startup:
 Customize the error response
 ----------------------------
 
-When CSRF validation fails, it will raise a :class:`CSRFError`.
-By default this returns a response with the failure reason and a 400 code.
-You can customize the error response using Flask's
-:meth:`~flask.Flask.errorhandler`. ::
+When CSRF validation fails on a request protected by :class:`CSRFProtect`,
+the extension raises a :class:`CSRFError`. By default this returns a response
+with the failure reason and a 400 code. You can customize the error response
+using Flask's :meth:`~flask.Flask.errorhandler`. ::
 
     from flask_wtf.csrf import CSRFError
 


### PR DESCRIPTION
<!--
If you have not contributed to the project before, open a ticket
describing the issue or feature the PR will address to allow discussion
first.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

Per davidism's note on the linked issue: "the docs could be clearer that the extension raises the error, not forms. PRs welcome." This narrows the sentence in the "Customize the error response" section so it explicitly names `CSRFProtect` as the raiser, avoiding the implication that `FlaskForm.validate_on_submit` raises `CSRFError`.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #381

<!--
Ensure each step for contributing is complete by adding an "x" to each
box below.

If only docs were changed, these aren't relevant and can be removed.
-->
