### PR TITLE
AI junk

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,8 @@ Released 2026-04-23
 - Add ``apply_exemptions`` parameter to
   :meth:`~flask_wtf.csrf.CSRFProtect.protect` so ``@csrf.exempt`` keeps working
   when validation is triggered manually. :pr:`419`
+- Document generating a CSRF token before returning streamed templates.
+  :issue:`668`
 - Add ``RECAPTCHA_ENABLED`` setting. :pr:`509`
 
 Version 1.2.2

--- a/docs/csrf.rst
+++ b/docs/csrf.rst
@@ -66,6 +66,19 @@ The ``name`` attribute must match the ``WTF_CSRF_FIELD_NAME`` setting
 ``Bad Request: CSRF token missing`` error. Change the setting if you need a
 different field name.
 
+Streaming responses send headers before the template is fully iterated.
+If a streamed template is the first place in the request that calls
+``csrf_token()``, the session cookie that stores the raw CSRF token may not be
+sent to the browser. Call :func:`generate_csrf` before returning the streaming
+response so the token is generated while headers can still be modified.
+
+.. sourcecode:: python
+
+    @app.route("/stream-form")
+    def stream_form():
+        generate_csrf()
+        return stream_template("form.html")
+
 HTML Meta Tag
 -------------
 


### PR DESCRIPTION
Document the streaming-template CSRF caveat from #668: when a streamed template is the first code path that calls `csrf_token()`, response headers may already be sent before the session cookie can be updated. The docs now show calling `generate_csrf()` before returning the streamed response.

Fixes #668

Checklist:

- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue.

Validation:

- `uv sync --all-groups`
- `uv run tox -e docs`
- `uv run pre-commit run --files docs/csrf.rst docs/changes.rst`

Tests were not added because this is a documentation-only change.
